### PR TITLE
change gas limit constant to be in sync with Basbylon

### DIFF
--- a/pytezos/operation/fees.py
+++ b/pytezos/operation/fees.py
@@ -1,6 +1,6 @@
 from pytezos.operation.forge import forge_operation
 
-hard_gas_limit_per_operation = 400000
+hard_gas_limit_per_operation = 800000
 hard_storage_limit_per_operation = 60000
 minimal_fees = 100
 minimal_nanotez_per_byte = 1


### PR DESCRIPTION
Consider pulling constants from node `<node url>/chains/main/blocks/head/context/constants` instead of hardcoding them.

Also use `time_between_blocks` protocol constant instead of hardcoded `block_time` in 
[`ShellQuery.wait_next_block()`] (https://github.com/baking-bad/pytezos/blob/master/pytezos/rpc/shell.py#L66)
