### PR TITLE
Updated hard_gas_limit_per_operation to Carthage

### DIFF
--- a/pytezos/operation/fees.py
+++ b/pytezos/operation/fees.py
@@ -1,6 +1,6 @@
 from pytezos.operation.forge import forge_operation
 
-hard_gas_limit_per_operation = 800000
+hard_gas_limit_per_operation = 1040000
 hard_storage_limit_per_operation = 60000
 minimal_fees = 100
 minimal_nanotez_per_byte = 1


### PR DESCRIPTION
Hi all,

The main net is now on Carthage net from what I understand [1] and the gas limit per operation was updated from 800,000 to 1,040,000 [2]. The constant `hard_gas_limit_per_operation` in fees.py needs to be updated as it prevents this new limit from being used. Otherwise, the `autofill` function fails with `pytezos.rpc.node.RpcError: ({'id': 'proto.006-PsCARTHA.gas_exhausted.operation', 'kind': 'temporary'},)` when calling the contract on entrypoints that use more than 800.000 gas and a sandbox that accepts 1.040.000 gas operations with `tezos-client`.

There might be other stuff to change that I don't know of, let me know and I can update the request :) But in the current state of affairs, this single line breaks my CI that's running on a Carthage parametered sandbox.

Cheers,

Thomas

[1] https://cryptopotato.com/tezos-successfully-activated-carthage-its-third-protocol-update-xtz-price-surpasses-3/
[2] https://tezos.gitlab.io/protocols/006_carthage.html#smart-contracts