### PR TITLE
Minimalistic Dockerfile, based on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+ARG version="2.4.5"
+
+FROM python:3-alpine
+ARG version
+
+RUN apk update \
+	&& apk --no-cache add --virtual \
+		build-deps \
+		build-base \
+		autoconf \
+		automake \
+		git \
+		gmp-dev \
+		isl \
+		libatomic \
+		libffi-dev \
+		libgomp \
+		libressl-dev \
+		libtool \
+		make \
+		mpfr4 \
+		mpc1 \
+		musl-dev \
+		openssl \
+	&& apk --no-cache add \
+		binutils \
+		libsodium-dev \
+	&& git clone https://github.com/bitcoin-core/secp256k1.git /tmp/secp256k1 && cd /tmp/secp256k1 \
+	&& ./autogen.sh \
+	&& ./configure \
+	&& make install \
+	&& cd / && rm -rf /tmp/secp256k1 \
+	&& pip3 install poetry==1.0.5 \
+	&& pip3 install --no-build-isolation pendulum==2.1.0 \
+	&& pip3 install pytezos==${version} \
+	&& pip3 uninstall --yes poetry \
+	&& apk del build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM python:3-alpine
 ARG version
 
 RUN apk update \
-	&& apk --no-cache add --virtual \
-		build-deps \
+	&& apk --no-cache add --virtual build-deps \
 		build-base \
 		autoconf \
 		automake \


### PR DESCRIPTION
Creates a minimal Docker image, perfect for CI/CD or just general dev/testing.

Currently, there only appears to be a single PyTezos image on Docker Hub: `yourlabs/pytezos`, which is 236 MB.
This creates a resulting image of just 162 MB.

PyTezos is installed from PyPI, rather than doing a `poerty install`, to avoid having the code base within the image _(emphasis on size)_

