### PR TITLE
Fix units in minimal fee constants

### DIFF
--- a/pytezos/operation/fees.py
+++ b/pytezos/operation/fees.py
@@ -3,8 +3,8 @@ from pytezos.operation.forge import forge_operation
 hard_gas_limit_per_operation = 1040000
 hard_storage_limit_per_operation = 60000
 minimal_fees = 100
-minimal_nanotez_per_byte = 1
-minimal_nanotez_per_gas_unit = .1
+minimal_mutez_per_byte = 1
+minimal_mutez_per_gas_unit = .1
 
 
 def calculate_fee(content: dict, consumed_gas: int, extra_size: int, reserve=10) -> int:
@@ -17,8 +17,8 @@ def calculate_fee(content: dict, consumed_gas: int, extra_size: int, reserve=10)
     """
     size = len(forge_operation(content)) + extra_size
     fee = minimal_fees \
-        + minimal_nanotez_per_byte * size \
-        + int(minimal_nanotez_per_gas_unit * consumed_gas)
+        + minimal_mutez_per_byte * size \
+        + int(minimal_mutez_per_gas_unit * consumed_gas)
     return fee + reserve
 
 


### PR DESCRIPTION
Based on the [baker defaults](https://tezos.gitlab.io/protocols/003_PsddFKi3.html#baker):
```
minimal_nanotez_per_gas_unit = 100nꜩ/gu (0.000 000 1ꜩ/gu)
minimal_nanotez_per_byte = 1000nꜩ/B (0.000 001ꜩ/B)
```
It is easier to keep everything in mutez and therefore the amounts above were divided by 1000. However the constant names were not changed from nanotez to mutez.