### PR TITLE
Replace print statements with logging ones

### DIFF
--- a/pytezos/__init__.py
+++ b/pytezos/__init__.py
@@ -21,5 +21,6 @@ from pytezos.michelson.forge import forge_micheline, unforge_micheline
 from pytezos.michelson.types.core import Unit
 from pytezos.michelson.types.base import Undefined, MichelsonType
 from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.logging import logger
 
 pytezos = PyTezosClient()

--- a/pytezos/client.py
+++ b/pytezos/client.py
@@ -2,6 +2,8 @@ from typing import Optional, Union
 from decimal import Decimal
 
 from pytezos.rpc import ShellQuery
+from pytezos.logging import logger
+import logging
 from pytezos.crypto.key import Key
 from pytezos.operation.group import OperationGroup
 from pytezos.operation.content import ContentMixin
@@ -119,3 +121,11 @@ class PyTezosClient(ContextMixin, ContentMixin):
         :returns: A copy of current object with changes applied
         """
         return PyTezosClient(context=self._spawn_context(shell=shell, key=key, mode=mode))
+
+    @property
+    def loglevel(self) -> int:
+        return logger.level
+
+    @loglevel.setter
+    def loglevel(self, value: Union[str, int]) -> None:
+        logger.setLevel(value)

--- a/pytezos/contract/call.py
+++ b/pytezos/contract/call.py
@@ -4,6 +4,7 @@ from typing import Union
 from deprecation import deprecated
 
 from pytezos.contract.result import ContractCallResult
+from pytezos.logging import logger
 from pytezos.operation.group import OperationGroup
 from pytezos.jupyter import get_class_docstring
 from pytezos.context.mixin import ContextMixin
@@ -119,7 +120,7 @@ class ContractCall(ContextMixin):
             address=self_address
         )
         if error:
-            print('\n'.join(stdout))
+            logger.debug('\n'.join(stdout))
             raise error
         res = {
             'operations': operations,
@@ -207,6 +208,6 @@ class ContractCall(ContextMixin):
             context=self.context
         )
         if error:
-            print('\n'.join(stdout))
+            logger.debug('\n'.join(stdout))
             raise error
         return res

--- a/pytezos/contract/entrypoint.py
+++ b/pytezos/contract/entrypoint.py
@@ -1,6 +1,7 @@
 from pprint import pformat
 from typing import Optional
 
+from pytezos.logging import logger
 from pytezos.contract.call import ContractCall
 from pytezos.context.mixin import ContextMixin, ExecutionContext
 from pytezos.michelson.sections.parameter import ParameterSection
@@ -76,5 +77,5 @@ class ContractEntrypoint(ContextMixin):
             return param_ty.from_python_object({self.entrypoint: py_obj}) \
                 .to_parameters(mode=mode or self.context.mode)
         except MichelsonRuntimeError as e:
-            print(self.__doc__)
+            logger.info(self.__doc__)
             raise ValueError(f'Unexpected arguments: {pformat(py_obj)}', *e.args)

--- a/pytezos/logging.py
+++ b/pytezos/logging.py
@@ -1,0 +1,26 @@
+import logging
+import logging.config
+
+DEFAULT_LOGGER_CONFIG = {
+    'version': 1,
+    'formatters': {
+        'brief': {
+            'format': '%(message)s',
+        },
+    },
+    'handlers': {
+        'default': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'brief',
+            'stream': 'ext://sys.stdout',
+        }
+    },
+    'root': { 
+        'handlers': ['default'],
+        'level': 'INFO',
+        'propagate': False
+    }
+}
+
+logging.config.dictConfig(DEFAULT_LOGGER_CONFIG)
+logger = logging.getLogger()

--- a/pytezos/michelson/format.py
+++ b/pytezos/michelson/format.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime
-from pprint import pprint
+from pprint import pformat
+
+from pytezos.logging import logger
 
 line_size = 100
 
@@ -122,5 +124,5 @@ def micheline_to_michelson(data, inline=False, wrap=False) -> str:
         else:
             return res
     except (KeyError, IndexError, TypeError) as e:
-        pprint(data, compact=True)
+        logger.info(data, compact=True)
         raise MichelsonFormatterError(e.args)

--- a/pytezos/operation/group.py
+++ b/pytezos/operation/group.py
@@ -2,6 +2,7 @@ from pprint import pformat
 from typing import List, Optional, Any, Dict
 
 from pytezos.crypto.key import blake2b_32
+from pytezos.logging import logger
 from pytezos.operation.content import ContentMixin
 from pytezos.operation.forge import forge_operation_group
 from pytezos.operation.fees import calculate_fee, default_fee, default_gas_limit, default_storage_limit
@@ -302,7 +303,7 @@ class OperationGroup(ContextMixin, ContentMixin):
                     pending_opg = self.shell.mempool.pending_operations[opg_hash]
                     if not OperationResult.is_applied(pending_opg):
                         raise RpcError.from_errors(OperationResult.errors(pending_opg))
-                    print(f'Still in mempool: {opg_hash}')
+                    logger.info('Still in mempool: %s' % opg_hash)
                 except StopIteration:
                     res = self.shell.blocks[-(i + 1):].find_operation(opg_hash)
                     if check_result:

--- a/pytezos/rpc/search.py
+++ b/pytezos/rpc/search.py
@@ -1,5 +1,5 @@
 from typing import Any, Callable, Generator
-from loguru import logger
+from pytezos.logging import logger
 
 from pytezos.rpc.node import RpcError
 from pytezos.rpc.query import RpcQuery
@@ -10,14 +10,14 @@ from pytezos.crypto.encoding import is_bh
 def find_state_change_intervals(head: int, last: int, get: Callable, equals: Callable,
                                 step=60) -> Generator:
     succ_value = get(head)
-    logger.debug(f'{succ_value} at head {head}')
+    logger.debug('%s at head %s' % succ_value, head)
 
     for level in range(head - step, last, -step):
         value = get(level)
-        logger.debug(f'{value} at level {level}')
+        logger.debug('%s at level %s' % value, level)
 
         if not equals(value, succ_value):
-            logger.debug(f'{value} -> {succ_value} at ({level}, {level + step})')
+            logger.debug('%s -> %s at (%s, {level + step})' % value, succ_value, level)
             yield level + step, succ_value, level, value
             succ_value = value
 
@@ -30,7 +30,7 @@ def find_state_change(head: int, last: int, get: Callable, equals: Callable,
 
         level = (end + start) // 2
         value = get(level)
-        logger.debug(f'{value} at level {level}')
+        logger.debug('%s at level %s' % value, level)
 
         if equals(value, pred_value):
             return bisect(level, end)
@@ -46,7 +46,7 @@ def walk_state_change_interval(head: int, last: int, get: Callable, equals: Call
     value = last_value
     while not equals(value, head_value):
         level, value = find_state_change(head, level, get, equals, pred_value=value)
-        logger.debug(f'{last_value} -> {value} at {level}')
+        logger.debug('%s -> %s at %s' % last_value, value, level)
         yield level, value
 
 
@@ -203,7 +203,7 @@ class BlockSliceQuery(RpcQuery):
 
         for block_level in levels:
             try:
-                logger.debug(f'checking level {block_level}...')
+                logger.debug(f'checking level %s...' % block_level)
                 return self._getitem(block_level).operations[operation_group_hash]()
             except StopIteration:
                 continue

--- a/pytezos/rpc/shell.py
+++ b/pytezos/rpc/shell.py
@@ -6,6 +6,7 @@ from binascii import hexlify
 from datetime import datetime
 from time import sleep
 
+from pytezos.logging import logger
 from pytezos.crypto.encoding import base58_decode
 from pytezos.rpc.query import RpcQuery
 from pytezos.jupyter import get_attr_docstring
@@ -85,7 +86,7 @@ class ShellQuery(RpcQuery, path=''):
         prev_block_dt = datetime.strptime(header['timestamp'], '%Y-%m-%dT%H:%M:%SZ')
         elapsed_sec = (datetime.utcnow() - prev_block_dt).seconds
         delay_sec = 0 if elapsed_sec > time_between_blocks else time_between_blocks - elapsed_sec
-        print(f'Wait {delay_sec} seconds until block {block_hash} is finalized')
+        logger.info('Wait %s seconds until block %s is finalized' % delay_sec, block_hash)
         sleep(delay_sec)
 
         for i in range(time_between_blocks):

--- a/scripts/fetch_contract_data.py
+++ b/scripts/fetch_contract_data.py
@@ -4,6 +4,8 @@ import json
 from os import makedirs
 from os.path import dirname, join, exists
 
+from pytezos.logging import logger
+
 network = 'mainnet'
 api_host = 'test.better-call.dev'
 since = 1590969600
@@ -100,9 +102,8 @@ def fetch_contract_samples(max_count=100):
                                                 operation['internal'],
                                                 contract['address'])
                 write_test_data(folder, entrypoint, result)
-        print(name)
+        logger.info(name)
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
     fetch_contract_samples()


### PR DESCRIPTION
Setting loglevel:
```python
from pytezos import pytezos
pytezos.loglevel = 'WARNING'
```

stdout prints in `pytezos.contract.call` module are now at DEBUG level. Existing  message format is not changed.