### PR TITLE
Initial pylint integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 debug:
 	pip install . --force --no-deps
 
+isort:
+	poetry run isort pytezos
+
+pylint:
+	poetry run pylint pytezos || poetry run pylint-exit $$?
+
+lint: isort pylint
+
 test:
 	pytest -v .
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,6 +18,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "astroid"
+version = "2.5.1"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0"
+typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
+wrapt = ">=1.11,<1.13"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -288,6 +301,19 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "isort"
+version = "5.7.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+
+[[package]]
 name = "jinja2"
 version = "2.11.3"
 description = "A very fast and expressive template engine."
@@ -300,6 +326,14 @@ MarkupSafe = ">=0.23"
 
 [package.extras]
 i18n = ["Babel (>=0.8)"]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.5.2"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "loguru"
@@ -324,6 +358,14 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mnemonic"
@@ -463,6 +505,32 @@ description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "pylint"
+version = "2.7.2"
+description = "python code static checker"
+category = "dev"
+optional = false
+python-versions = "~=3.6"
+
+[package.dependencies]
+astroid = ">=2.5.1,<2.6"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+isort = ">=4.2.5,<6"
+mccabe = ">=0.6,<0.7"
+toml = ">=0.7.1"
+
+[package.extras]
+docs = ["sphinx (==3.5.1)", "python-docs-theme (==2020.12)"]
+
+[[package]]
+name = "pylint-exit"
+version = "1.2.0"
+description = "Exit code handler for pylint command line utility."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pyparsing"
@@ -771,6 +839,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "toolz"
 version = "0.11.1"
 description = "List processing tools and functional utilities"
@@ -789,6 +865,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
 telegram = ["requests"]
+
+[[package]]
+name = "typed-ast"
+version = "1.4.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -823,6 +907,14 @@ python-versions = ">=3.5"
 dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 
 [[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
 version = "3.4.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -837,7 +929,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "a06efa007869076e9bc2663ab62a7bed3ccb67570c824dbaff783cc127a18982"
+content-hash = "6abd8344746ea453013fa356edd478ce865d8ba74d86e1ad21de4bc31fe5f47a"
 
 [metadata.files]
 aiocontextvars = [
@@ -847,6 +939,10 @@ aiocontextvars = [
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+astroid = [
+    {file = "astroid-2.5.1-py3-none-any.whl", hash = "sha256:21d735aab248253531bb0f1e1e6d068f0ee23533e18ae8a6171ff892b98297cf"},
+    {file = "astroid-2.5.1.tar.gz", hash = "sha256:cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1037,9 +1133,39 @@ importlib-metadata = [
     {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
     {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
+isort = [
+    {file = "isort-5.7.0-py3-none-any.whl", hash = "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"},
+    {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
+]
 jinja2 = [
     {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
     {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.5.2.tar.gz", hash = "sha256:5944a9b95e97de1980c65f03b79b356f30a43de48682b8bdd90aa5089f0ec1f4"},
+    {file = "lazy_object_proxy-1.5.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e960e8be509e8d6d618300a6c189555c24efde63e85acaf0b14b2cd1ac743315"},
+    {file = "lazy_object_proxy-1.5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:522b7c94b524389f4a4094c4bf04c2b02228454ddd17c1a9b2801fac1d754871"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3782931963dc89e0e9a0ae4348b44762e868ea280e4f8c233b537852a8996ab9"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:429c4d1862f3fc37cd56304d880f2eae5bd0da83bdef889f3bd66458aac49128"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win32.whl", hash = "sha256:cd1bdace1a8762534e9a36c073cd54e97d517a17d69a17985961265be6d22847"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ddbdcd10eb999d7ab292677f588b658372aadb9a52790f82484a37127a390108"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ecb5dd5990cec6e7f5c9c1124a37cb2c710c6d69b0c1a5c4aa4b35eba0ada068"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b6577f15d5516d7d209c1a8cde23062c0f10625f19e8dc9fb59268859778d7d7"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win32.whl", hash = "sha256:c8fe2d6ff0ff583784039d0255ea7da076efd08507f2be6f68583b0da32e3afb"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:fa5b2dee0e231fa4ad117be114251bdfe6afe39213bd629d43deb117b6a6c40a"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1d33d6f789697f401b75ce08e73b1de567b947740f768376631079290118ad39"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:57fb5c5504ddd45ed420b5b6461a78f58cbb0c1b0cbd9cd5a43ad30a4a3ee4d0"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win32.whl", hash = "sha256:e7273c64bccfd9310e9601b8f4511d84730239516bada26a0c9846c9697617ef"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f4e5e68b7af950ed7fdb594b3f19a0014a3ace0fedb86acb896e140ffb24302"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cadfa2c2cf54d35d13dc8d231253b7985b97d629ab9ca6e7d672c35539d38163"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e7428977763150b4cf83255625a80a23dfdc94d43be7791ce90799d446b4e26f"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win32.whl", hash = "sha256:2f2de8f8ac0be3e40d17730e0600619d35c78c13a099ea91ef7fb4ad944ce694"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:38c3865bd220bd983fcaa9aa11462619e84a71233bafd9c880f7b1cb753ca7fa"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:8a44e9901c0555f95ac401377032f6e6af66d8fc1fbfad77a7a8b1a826e0b93c"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fa7fb7973c622b9e725bee1db569d2c2ee64d2f9a089201c5e8185d482c7352d"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:71a1ef23f22fa8437974b2d60fedb947c99a957ad625f83f43fd3de70f77f458"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win32.whl", hash = "sha256:ef3f5e288aa57b73b034ce9c1f1ac753d968f9069cd0742d1d69c698a0167166"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:37d9c34b96cca6787fe014aeb651217944a967a5b165e2cacb6b858d2997ab84"},
 ]
 loguru = [
     {file = "loguru-0.5.3-py3-none-any.whl", hash = "sha256:f8087ac396b5ee5f67c963b495d615ebbceac2796379599820e324419d53667c"},
@@ -1064,21 +1190,44 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mnemonic = [
     {file = "mnemonic-0.19-py2.py3-none-any.whl", hash = "sha256:a8d78c5100acfa7df9bab6b9db7390831b0e54490934b718ff9efd68f0d731a6"},
@@ -1160,6 +1309,14 @@ pycparser = [
 pygments = [
     {file = "Pygments-2.7.4-py3-none-any.whl", hash = "sha256:bc9591213a8f0e0ca1a5e68a479b4887fdc3e75d0774e5c71c31920c427de435"},
     {file = "Pygments-2.7.4.tar.gz", hash = "sha256:df49d09b498e83c1a73128295860250b0b7edd4c723a32e9bc0d295c7c2ec337"},
+]
+pylint = [
+    {file = "pylint-2.7.2-py3-none-any.whl", hash = "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"},
+    {file = "pylint-2.7.2.tar.gz", hash = "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a"},
+]
+pylint-exit = [
+    {file = "pylint-exit-1.2.0.zip", hash = "sha256:b6ad02884c01c5560a5275079fe5a6c792afff90ecccf0c02513e1547ee280b0"},
+    {file = "pylint_exit-1.2.0-py2.py3-none-any.whl", hash = "sha256:65c9e7856e9058705a92d7c45628d604b2a4b8ee2b3c18a7303be77f9ed87cbe"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1345,6 +1502,10 @@ strict-rfc3339 = [
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 toolz = [
     {file = "toolz-0.11.1-py3-none-any.whl", hash = "sha256:1bc473acbf1a1db4e72a1ce587be347450e8f08324908b8a266b486f408f04d5"},
     {file = "toolz-0.11.1.tar.gz", hash = "sha256:c7a47921f07822fe534fb1c01c9931ab335a4390c782bd28c6bcc7c2f71f3fbf"},
@@ -1352,6 +1513,38 @@ toolz = [
 tqdm = [
     {file = "tqdm-4.56.2-py2.py3-none-any.whl", hash = "sha256:a89be573bfddb81bb0b395a416d5e55e3ecc73ce95a368a4f6360bedea33195e"},
     {file = "tqdm-4.56.2.tar.gz", hash = "sha256:11d544652edbdfc9cc41aa4c8a5c166513e279f3f2d9f1a9e1c89935b51de6ff"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
@@ -1365,6 +1558,9 @@ urllib3 = [
 win32-setctime = [
     {file = "win32_setctime-1.0.3-py3-none-any.whl", hash = "sha256:dc925662de0a6eb987f0b01f599c01a8236cb8c62831c22d9cada09ad958243e"},
     {file = "win32_setctime-1.0.3.tar.gz", hash = "sha256:4e88556c32fdf47f64165a2180ba4552f8bb32c1103a2fafd05723a0bd42bd4b"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
     {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,5 @@
+[FORMAT]
+max-line-length=140
+
+[MESSAGES CONTROL]
+disable=missing-docstring,unsubscriptable-object,invalid-name,too-many-arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,16 @@ sphinx = "*"
 sphinx_rtd_theme = { git = "https://github.com/readthedocs/sphinx_rtd_theme.git", tag = "0.5.0rc2" }
 sphinx-sitemap = "*"
 sphinxcontrib-googleanalytics = "^0.1"
+pylint = "^2.7.2"
+pylint-exit = "^1.2.0"
+isort = "^5.7.0"
 
 [tool.poetry.scripts]
 pytezos = 'pytezos:cli.cli.main'
+
+[tool.isort]
+force_single_line = true
+line_length = 140
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "cryptography==3.3.2", "wheel"]

--- a/pytezos/__init__.py
+++ b/pytezos/__init__.py
@@ -11,15 +11,18 @@ And follow the interactive documentation.
 """
 
 from pytezos.client import PyTezosClient
+from pytezos.contract.interface import Contract
+from pytezos.contract.interface import ContractInterface
 from pytezos.crypto.key import Key
+from pytezos.michelson.forge import forge_micheline
+from pytezos.michelson.forge import unforge_micheline
+from pytezos.michelson.format import micheline_to_michelson
+from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.michelson.parse import michelson_to_micheline
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import Undefined
+from pytezos.michelson.types.core import Unit
 from pytezos.operation.group import OperationGroup
 from pytezos.operation.result import OperationResult
-from pytezos.contract.interface import ContractInterface, Contract
-from pytezos.michelson.format import micheline_to_michelson
-from pytezos.michelson.parse import michelson_to_micheline
-from pytezos.michelson.forge import forge_micheline, unforge_micheline
-from pytezos.michelson.types.core import Unit
-from pytezos.michelson.types.base import Undefined, MichelsonType
-from pytezos.michelson.micheline import MichelsonRuntimeError
 
 pytezos = PyTezosClient()

--- a/pytezos/cli/cli.py
+++ b/pytezos/cli/cli.py
@@ -1,14 +1,20 @@
 from glob import glob
-from os.path import abspath, dirname, join, exists
+from os.path import abspath
+from os.path import dirname
+from os.path import exists
+from os.path import join
 from pprint import pprint
+
 import fire
 
-from pytezos import pytezos, ContractInterface
-from pytezos.rpc.errors import RpcError
-from pytezos.operation.result import OperationResult
+from pytezos import ContractInterface
+from pytezos import pytezos
+from pytezos.cli.github import create_deployment
+from pytezos.cli.github import create_deployment_status
 from pytezos.context.mixin import default_network
 from pytezos.michelson.types.base import generate_pydoc
-from pytezos.cli.github import create_deployment, create_deployment_status
+from pytezos.operation.result import OperationResult
+from pytezos.rpc.errors import RpcError
 
 kernel_js_path = join(dirname(dirname(__file__)), 'assets', 'kernel.js')
 kernel_json = {

--- a/pytezos/cli/github.py
+++ b/pytezos/cli/github.py
@@ -1,5 +1,6 @@
-import requests
 from os.path import join
+
+import requests
 
 
 def create_deployment(repo_slug, oauth_token, environment, ref='master'):

--- a/pytezos/client.py
+++ b/pytezos/client.py
@@ -1,14 +1,15 @@
-from typing import Optional, Union
 from decimal import Decimal
+from typing import Optional
+from typing import Union
 
-from pytezos.rpc import ShellQuery
-from pytezos.crypto.key import Key
-from pytezos.operation.group import OperationGroup
-from pytezos.operation.content import ContentMixin
-from pytezos.contract.interface import ContractInterface
-from pytezos.contract.call import ContractCall
 from pytezos.context.mixin import ContextMixin
+from pytezos.contract.call import ContractCall
+from pytezos.contract.interface import ContractInterface
+from pytezos.crypto.key import Key
 from pytezos.jupyter import get_class_docstring
+from pytezos.operation.content import ContentMixin
+from pytezos.operation.group import OperationGroup
+from pytezos.rpc import ShellQuery
 
 
 class PyTezosClient(ContextMixin, ContentMixin):

--- a/pytezos/context/abstract.py
+++ b/pytezos/context/abstract.py
@@ -1,8 +1,10 @@
-from typing import Tuple, Optional
+from typing import Optional
+from typing import Tuple
 
 from pyblake2 import blake2b
 
-from pytezos.crypto.encoding import base58_decode, base58_encode
+from pytezos.crypto.encoding import base58_decode
+from pytezos.crypto.encoding import base58_encode
 from pytezos.crypto.key import Key
 
 

--- a/pytezos/context/impl.py
+++ b/pytezos/context/impl.py
@@ -1,12 +1,14 @@
-from typing import Tuple, Optional
 from datetime import datetime
+from typing import Optional
+from typing import Tuple
 
-from pytezos.rpc.errors import RpcError
-from pytezos.crypto.key import Key
-from pytezos.rpc.shell import ShellQuery
-from pytezos.context.abstract import AbstractContext, get_originated_address
+from pytezos.context.abstract import AbstractContext
+from pytezos.context.abstract import get_originated_address
 from pytezos.crypto.encoding import base58_encode
+from pytezos.crypto.key import Key
 from pytezos.michelson.micheline import get_script_section
+from pytezos.rpc.errors import RpcError
+from pytezos.rpc.shell import ShellQuery
 
 
 class ExecutionContext(AbstractContext):

--- a/pytezos/context/mixin.py
+++ b/pytezos/context/mixin.py
@@ -1,12 +1,18 @@
-from os.path import exists, expanduser
-from typing import Optional, Union
+from os.path import exists
+from os.path import expanduser
+from typing import Optional
+from typing import Union
 
-from pytezos.rpc.errors import RpcError
-from pytezos.rpc import ShellQuery, RpcNode, RpcMultiNode
-from pytezos.crypto.key import Key, is_installed
-from pytezos.crypto.encoding import is_public_key, is_pkh
-from pytezos.jupyter import InlineDocstring
 from pytezos.context.impl import ExecutionContext
+from pytezos.crypto.encoding import is_pkh
+from pytezos.crypto.encoding import is_public_key
+from pytezos.crypto.key import Key
+from pytezos.crypto.key import is_installed
+from pytezos.jupyter import InlineDocstring
+from pytezos.rpc import RpcMultiNode
+from pytezos.rpc import RpcNode
+from pytezos.rpc import ShellQuery
+from pytezos.rpc.errors import RpcError
 
 default_network = 'edo2net'
 default_key = 'edsk33N474hxzA4sKeWVM6iuGNGDpX2mGwHNxEA4UbWS8sW3Ta3NKH'  # please, use responsibly

--- a/pytezos/contract/call.py
+++ b/pytezos/contract/call.py
@@ -1,17 +1,19 @@
-from pprint import pformat
 from decimal import Decimal
+from pprint import pformat
 from typing import Union
+
 from deprecation import deprecated
 
-from pytezos.contract.result import ContractCallResult
-from pytezos.operation.group import OperationGroup
-from pytezos.jupyter import get_class_docstring
-from pytezos.context.mixin import ContextMixin
-from pytezos.michelson.format import micheline_to_michelson
-from pytezos.operation.content import format_tez, format_mutez
 from pytezos.context.impl import ExecutionContext
+from pytezos.context.mixin import ContextMixin
+from pytezos.contract.result import ContractCallResult
+from pytezos.jupyter import get_class_docstring
+from pytezos.michelson.format import micheline_to_michelson
 from pytezos.michelson.repl import Interpreter
 from pytezos.michelson.sections.storage import StorageSection
+from pytezos.operation.content import format_mutez
+from pytezos.operation.content import format_tez
+from pytezos.operation.group import OperationGroup
 
 
 def skip_nones(**kwargs) -> dict:

--- a/pytezos/contract/data.py
+++ b/pytezos/contract/data.py
@@ -1,12 +1,15 @@
-from typing import Optional, Union
+from typing import Optional
+from typing import Union
+
 from deprecation import deprecated
 
 from pytezos.context.impl import ExecutionContext
 from pytezos.context.mixin import ContextMixin
-from pytezos.michelson.types.base import MichelsonType, generate_pydoc
+from pytezos.jupyter import get_class_docstring
 from pytezos.michelson.format import micheline_to_michelson
 from pytezos.michelson.parse import michelson_to_micheline
-from pytezos.jupyter import get_class_docstring
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import generate_pydoc
 
 
 class ContractData(ContextMixin):

--- a/pytezos/contract/entrypoint.py
+++ b/pytezos/contract/entrypoint.py
@@ -1,12 +1,13 @@
 from pprint import pformat
 from typing import Optional
 
+from pytezos.context.mixin import ContextMixin
+from pytezos.context.mixin import ExecutionContext
 from pytezos.contract.call import ContractCall
-from pytezos.context.mixin import ContextMixin, ExecutionContext
-from pytezos.michelson.sections.parameter import ParameterSection
+from pytezos.jupyter import get_class_docstring
 from pytezos.michelson.micheline import MichelsonRuntimeError
 from pytezos.michelson.parse import michelson_to_micheline
-from pytezos.jupyter import get_class_docstring
+from pytezos.michelson.sections.parameter import ParameterSection
 
 
 class ContractEntrypoint(ContextMixin):

--- a/pytezos/contract/interface.py
+++ b/pytezos/contract/interface.py
@@ -1,21 +1,26 @@
-import requests
-from os.path import exists, expanduser
-from typing import List, Optional, Union
-from deprecation import deprecated
 from decimal import Decimal
+from os.path import exists
+from os.path import expanduser
+from typing import List
+from typing import Optional
+from typing import Union
 
-from pytezos.rpc import ShellQuery
-from pytezos.crypto.key import Key
-from pytezos.operation.group import OperationGroup
-from pytezos.contract.result import ContractCallResult
-from pytezos.contract.entrypoint import ContractEntrypoint
-from pytezos.michelson.program import MichelsonProgram
+import requests
+from deprecation import deprecated
+
+from pytezos.context.mixin import ContextMixin
+from pytezos.context.mixin import ExecutionContext
 from pytezos.contract.data import ContractData
-from pytezos.context.mixin import ContextMixin, ExecutionContext
+from pytezos.contract.entrypoint import ContractEntrypoint
+from pytezos.contract.result import ContractCallResult
+from pytezos.crypto.key import Key
 from pytezos.jupyter import get_class_docstring
 from pytezos.michelson.format import micheline_to_michelson
 from pytezos.michelson.parse import michelson_to_micheline
+from pytezos.michelson.program import MichelsonProgram
 from pytezos.michelson.types.base import generate_pydoc
+from pytezos.operation.group import OperationGroup
+from pytezos.rpc import ShellQuery
 
 
 class ContractInterface(ContextMixin):

--- a/pytezos/contract/result.py
+++ b/pytezos/contract/result.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from pytezos.operation.result import OperationResult
 from pytezos.context.impl import ExecutionContext
 from pytezos.michelson.program import MichelsonProgram
+from pytezos.operation.result import OperationResult
 
 
 class ContractCallResult(OperationResult):

--- a/pytezos/crypto/key.py
+++ b/pytezos/crypto/key.py
@@ -1,13 +1,19 @@
-import hashlib
 import binascii
+import hashlib
 import json
-from os.path import expanduser, join, abspath
 from getpass import getpass
-from pyblake2 import blake2b
-from mnemonic import Mnemonic
+from os.path import abspath
+from os.path import expanduser
+from os.path import join
 
-from pytezos.crypto.encoding import scrub_input, base58_decode, base58_encode
-from pytezos.jupyter import InlineDocstring, get_class_docstring
+from mnemonic import Mnemonic
+from pyblake2 import blake2b
+
+from pytezos.crypto.encoding import base58_decode
+from pytezos.crypto.encoding import base58_encode
+from pytezos.crypto.encoding import scrub_input
+from pytezos.jupyter import InlineDocstring
+from pytezos.jupyter import get_class_docstring
 
 
 class CryptoExtraFallback:
@@ -22,12 +28,12 @@ class CryptoExtraFallback:
 
 
 try:
+    import fastecdsa.curve
+    import fastecdsa.ecdsa
+    import fastecdsa.encoding.sec1
+    import fastecdsa.keys
     import pysodium
     import secp256k1
-    import fastecdsa.ecdsa
-    import fastecdsa.keys
-    import fastecdsa.curve
-    import fastecdsa.encoding.sec1
     from fastecdsa.encoding.util import bytes_to_int
 except ImportError as e:
     pysodium = CryptoExtraFallback()

--- a/pytezos/jupyter.py
+++ b/pytezos/jupyter.py
@@ -1,5 +1,5 @@
-import re
 import inspect
+import re
 from functools import update_wrapper
 
 

--- a/pytezos/michelson/forge.py
+++ b/pytezos/michelson/forge.py
@@ -1,8 +1,10 @@
-import base58
-import strict_rfc3339
 from typing import Tuple
 
-from pytezos.crypto.encoding import base58_encode, base58_decode
+import base58
+import strict_rfc3339
+
+from pytezos.crypto.encoding import base58_decode
+from pytezos.crypto.encoding import base58_encode
 from pytezos.crypto.key import blake2b_32
 from pytezos.michelson.tags import prim_tags
 

--- a/pytezos/michelson/instructions/__init__.py
+++ b/pytezos/michelson/instructions/__init__.py
@@ -1,26 +1,99 @@
-from pytezos.michelson.instructions.adt import PairInstruction, CarInstruction, CdrInstruction, RightInstruction, \
-    LeftInstruction, UnpairInstruction, GetnInstruction, UpdatenInstruction
-from pytezos.michelson.instructions.arithmetic import AbsInstruction, AddInstruction, IsNatInstruction, EdivInstruction, \
-    LslInstruction, MulInstruction, LsrInstruction, NegInstruction, SubInstruction, IntInstruction
-from pytezos.michelson.instructions.compare import CompareInstruction, EqInstruction, GeInstruction, GtInstruction, \
-    LeInstruction, LtInstruction, NeqInstruction
-from pytezos.michelson.instructions.boolean import OrInstruction, XorInstruction, AndInstruction, NotInstruction
-from pytezos.michelson.instructions.control import FailwithInstruction, ApplyInstruction, IfConsInstruction, \
-    IfLeftInstruction, IfNoneInstruction, LambdaInstruction, LoopInstruction, LoopLeftInstruction, IfInstruction, \
-    DipnInstruction, DipInstruction, MapInstruction, ExecInstruction, IterInstruction, PushInstruction
-from pytezos.michelson.instructions.crypto import Blake2bInstruction, KeccakInstruction, Sha3Instruction, \
-    Sha256Instruction, HashKeyInstruction, Sha512Instruction, CheckSignatureInstruction, SaplingEmptyStateInstruction, \
-    PairingCheckInstruction, SaplingVerifyUpdateInstruction
-from pytezos.michelson.instructions.generic import ConcatInstruction, NeverInstruction, SliceInstruction, \
-    UnpackInstruction, PackInstruction, SizeInstruction, UnitInstruction
-from pytezos.michelson.instructions.stack import DropnInstruction, RenameInstruction, SwapInstruction, \
-    DupnInstruction, DropInstruction, DigInstruction, PushInstruction, DugInstruction, DupInstruction
-from pytezos.michelson.instructions.struct import EmptyMapInstruction, EmptySetInstruction, EmptyBigMapInstruction, \
-    ConsInstruction, NoneInstruction, UpdateInstruction, GetAndUpdateInstruction, SomeInstruction, MemInstruction, \
-    GetInstruction, NilInstruction
-from pytezos.michelson.instructions.tezos import AddressInstruction, AmountInstruction, BalanceInstruction, \
-    ContractInstruction, SenderInstruction, CreateContractInstruction, ChainIdInstruction, SourceInstruction, \
-    NowInstruction, SelfInstruction, SetDelegateInstruction, ImplicitAccountInstruction, TransferTokensInstruction, \
-    SelfAddressInstruction
-from pytezos.michelson.instructions.ticket import TicketInstruction, SplitTicketInstruction, ReadTicketInstruction, \
-    JoinTicketsInstruction
+from pytezos.michelson.instructions.adt import CarInstruction
+from pytezos.michelson.instructions.adt import CdrInstruction
+from pytezos.michelson.instructions.adt import GetnInstruction
+from pytezos.michelson.instructions.adt import LeftInstruction
+from pytezos.michelson.instructions.adt import PairInstruction
+from pytezos.michelson.instructions.adt import RightInstruction
+from pytezos.michelson.instructions.adt import UnpairInstruction
+from pytezos.michelson.instructions.adt import UpdatenInstruction
+from pytezos.michelson.instructions.arithmetic import AbsInstruction
+from pytezos.michelson.instructions.arithmetic import AddInstruction
+from pytezos.michelson.instructions.arithmetic import EdivInstruction
+from pytezos.michelson.instructions.arithmetic import IntInstruction
+from pytezos.michelson.instructions.arithmetic import IsNatInstruction
+from pytezos.michelson.instructions.arithmetic import LslInstruction
+from pytezos.michelson.instructions.arithmetic import LsrInstruction
+from pytezos.michelson.instructions.arithmetic import MulInstruction
+from pytezos.michelson.instructions.arithmetic import NegInstruction
+from pytezos.michelson.instructions.arithmetic import SubInstruction
+from pytezos.michelson.instructions.boolean import AndInstruction
+from pytezos.michelson.instructions.boolean import NotInstruction
+from pytezos.michelson.instructions.boolean import OrInstruction
+from pytezos.michelson.instructions.boolean import XorInstruction
+from pytezos.michelson.instructions.compare import CompareInstruction
+from pytezos.michelson.instructions.compare import EqInstruction
+from pytezos.michelson.instructions.compare import GeInstruction
+from pytezos.michelson.instructions.compare import GtInstruction
+from pytezos.michelson.instructions.compare import LeInstruction
+from pytezos.michelson.instructions.compare import LtInstruction
+from pytezos.michelson.instructions.compare import NeqInstruction
+from pytezos.michelson.instructions.control import ApplyInstruction
+from pytezos.michelson.instructions.control import DipInstruction
+from pytezos.michelson.instructions.control import DipnInstruction
+from pytezos.michelson.instructions.control import ExecInstruction
+from pytezos.michelson.instructions.control import FailwithInstruction
+from pytezos.michelson.instructions.control import IfConsInstruction
+from pytezos.michelson.instructions.control import IfInstruction
+from pytezos.michelson.instructions.control import IfLeftInstruction
+from pytezos.michelson.instructions.control import IfNoneInstruction
+from pytezos.michelson.instructions.control import IterInstruction
+from pytezos.michelson.instructions.control import LambdaInstruction
+from pytezos.michelson.instructions.control import LoopInstruction
+from pytezos.michelson.instructions.control import LoopLeftInstruction
+from pytezos.michelson.instructions.control import MapInstruction
+from pytezos.michelson.instructions.control import PushInstruction
+from pytezos.michelson.instructions.crypto import Blake2bInstruction
+from pytezos.michelson.instructions.crypto import CheckSignatureInstruction
+from pytezos.michelson.instructions.crypto import HashKeyInstruction
+from pytezos.michelson.instructions.crypto import KeccakInstruction
+from pytezos.michelson.instructions.crypto import PairingCheckInstruction
+from pytezos.michelson.instructions.crypto import SaplingEmptyStateInstruction
+from pytezos.michelson.instructions.crypto import SaplingVerifyUpdateInstruction
+from pytezos.michelson.instructions.crypto import Sha3Instruction
+from pytezos.michelson.instructions.crypto import Sha256Instruction
+from pytezos.michelson.instructions.crypto import Sha512Instruction
+from pytezos.michelson.instructions.generic import ConcatInstruction
+from pytezos.michelson.instructions.generic import NeverInstruction
+from pytezos.michelson.instructions.generic import PackInstruction
+from pytezos.michelson.instructions.generic import SizeInstruction
+from pytezos.michelson.instructions.generic import SliceInstruction
+from pytezos.michelson.instructions.generic import UnitInstruction
+from pytezos.michelson.instructions.generic import UnpackInstruction
+from pytezos.michelson.instructions.stack import DigInstruction
+from pytezos.michelson.instructions.stack import DropInstruction
+from pytezos.michelson.instructions.stack import DropnInstruction
+from pytezos.michelson.instructions.stack import DugInstruction
+from pytezos.michelson.instructions.stack import DupInstruction
+from pytezos.michelson.instructions.stack import DupnInstruction
+from pytezos.michelson.instructions.stack import PushInstruction
+from pytezos.michelson.instructions.stack import RenameInstruction
+from pytezos.michelson.instructions.stack import SwapInstruction
+from pytezos.michelson.instructions.struct import ConsInstruction
+from pytezos.michelson.instructions.struct import EmptyBigMapInstruction
+from pytezos.michelson.instructions.struct import EmptyMapInstruction
+from pytezos.michelson.instructions.struct import EmptySetInstruction
+from pytezos.michelson.instructions.struct import GetAndUpdateInstruction
+from pytezos.michelson.instructions.struct import GetInstruction
+from pytezos.michelson.instructions.struct import MemInstruction
+from pytezos.michelson.instructions.struct import NilInstruction
+from pytezos.michelson.instructions.struct import NoneInstruction
+from pytezos.michelson.instructions.struct import SomeInstruction
+from pytezos.michelson.instructions.struct import UpdateInstruction
+from pytezos.michelson.instructions.tezos import AddressInstruction
+from pytezos.michelson.instructions.tezos import AmountInstruction
+from pytezos.michelson.instructions.tezos import BalanceInstruction
+from pytezos.michelson.instructions.tezos import ChainIdInstruction
+from pytezos.michelson.instructions.tezos import ContractInstruction
+from pytezos.michelson.instructions.tezos import CreateContractInstruction
+from pytezos.michelson.instructions.tezos import ImplicitAccountInstruction
+from pytezos.michelson.instructions.tezos import NowInstruction
+from pytezos.michelson.instructions.tezos import SelfAddressInstruction
+from pytezos.michelson.instructions.tezos import SelfInstruction
+from pytezos.michelson.instructions.tezos import SenderInstruction
+from pytezos.michelson.instructions.tezos import SetDelegateInstruction
+from pytezos.michelson.instructions.tezos import SourceInstruction
+from pytezos.michelson.instructions.tezos import TransferTokensInstruction
+from pytezos.michelson.instructions.ticket import JoinTicketsInstruction
+from pytezos.michelson.instructions.ticket import ReadTicketInstruction
+from pytezos.michelson.instructions.ticket import SplitTicketInstruction
+from pytezos.michelson.instructions.ticket import TicketInstruction

--- a/pytezos/michelson/instructions/adt.py
+++ b/pytezos/michelson/instructions/adt.py
@@ -1,9 +1,16 @@
-from typing import List, cast, Any, Type, Tuple
+from typing import Any
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import cast
 
-from pytezos.michelson.instructions.base import format_stdout, MichelsonInstruction
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import PairType, OrType, MichelsonType
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import MichelsonType
+from pytezos.michelson.types import OrType
+from pytezos.michelson.types import PairType
 
 
 def execute_cxr(prim: str, stack: MichelsonStack, stdout: List[str], idx: int):

--- a/pytezos/michelson/instructions/arithmetic.py
+++ b/pytezos/michelson/instructions/arithmetic.py
@@ -1,11 +1,26 @@
-from typing import List, Union, Tuple, Type, Callable, cast
+from typing import Callable
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
+
 from py_ecc import optimized_bls12_381 as bls12_381
 
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import IntType, NatType, TimestampType, MutezType, OptionType, PairType, \
-    BLS12_381_G1Type, BLS12_381_G2Type, BLS12_381_FrType
-from pytezos.michelson.instructions.base import MichelsonInstruction, dispatch_types, format_stdout
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import dispatch_types
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import BLS12_381_FrType
+from pytezos.michelson.types import BLS12_381_G1Type
+from pytezos.michelson.types import BLS12_381_G2Type
+from pytezos.michelson.types import IntType
+from pytezos.michelson.types import MutezType
+from pytezos.michelson.types import NatType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import PairType
+from pytezos.michelson.types import TimestampType
 
 
 class AbsInstruction(MichelsonInstruction, prim='ABS'):

--- a/pytezos/michelson/instructions/base.py
+++ b/pytezos/michelson/instructions/base.py
@@ -1,4 +1,11 @@
-from typing import List, Type, cast, Dict, Tuple, Any, Union, Optional
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
 from pytezos.context.abstract import AbstractContext
 from pytezos.michelson.micheline import Micheline

--- a/pytezos/michelson/instructions/boolean.py
+++ b/pytezos/michelson/instructions/boolean.py
@@ -1,9 +1,17 @@
-from typing import List, Callable, cast, Tuple, Union
+from typing import Callable
+from typing import List
+from typing import Tuple
+from typing import Union
+from typing import cast
 
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.instructions.base import dispatch_types, format_stdout, MichelsonInstruction
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import dispatch_types
+from pytezos.michelson.instructions.base import format_stdout
 from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import BoolType, NatType, IntType
+from pytezos.michelson.types import BoolType
+from pytezos.michelson.types import IntType
+from pytezos.michelson.types import NatType
 
 
 def execute_boolean_add(prim: str, stack: MichelsonStack, stdout: List[str], add: Callable):

--- a/pytezos/michelson/instructions/compare.py
+++ b/pytezos/michelson/instructions/compare.py
@@ -1,9 +1,13 @@
-from typing import List, Callable, cast
+from typing import Callable
+from typing import List
+from typing import cast
 
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.instructions.base import MichelsonInstruction, format_stdout
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
 from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import IntType, BoolType
+from pytezos.michelson.types import BoolType
+from pytezos.michelson.types import IntType
 
 
 def compare(a, b) -> int:

--- a/pytezos/michelson/instructions/control.py
+++ b/pytezos/michelson/instructions/control.py
@@ -1,14 +1,28 @@
-from typing import List, cast, Tuple, Union, Type
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.instructions.stack import PushInstruction
-from pytezos.michelson.instructions.adt import PairInstruction
-from pytezos.michelson.micheline import MichelineSequence, MichelsonRuntimeError, Micheline
-from pytezos.michelson.instructions.base import MichelsonInstruction, format_stdout
-from pytezos.michelson.types import MichelsonType, LambdaType, PairType, BoolType, ListType, OrType, OptionType, \
-    MapType, SetType
-from pytezos.michelson.stack import MichelsonStack
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.adt import PairInstruction
+from pytezos.michelson.instructions.base import MichelsonInstruction
 from pytezos.michelson.instructions.base import Wildcard
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.instructions.stack import PushInstruction
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import BoolType
+from pytezos.michelson.types import LambdaType
+from pytezos.michelson.types import ListType
+from pytezos.michelson.types import MapType
+from pytezos.michelson.types import MichelsonType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import OrType
+from pytezos.michelson.types import PairType
+from pytezos.michelson.types import SetType
 
 
 def execute_dip(prim: str, stack: MichelsonStack, stdout: List[str],

--- a/pytezos/michelson/instructions/crypto.py
+++ b/pytezos/michelson/instructions/crypto.py
@@ -1,15 +1,30 @@
+from hashlib import sha256
+from hashlib import sha512
+from typing import Callable
+from typing import List
+from typing import Tuple
+from typing import cast
+
 import sha3
-from hashlib import sha256, sha512
-from typing import List, Tuple, Callable, cast
 from py_ecc import optimized_bls12_381 as bls12_381
 from py_ecc.fields import optimized_bls12_381_FQ12 as FQ12
 
-from pytezos.crypto.key import blake2b_32, Key
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import BytesType, KeyType, SignatureType, BoolType, KeyHashType, SaplingStateType, \
-    ListType, BLS12_381_G1Type, BLS12_381_G2Type, PairType
-from pytezos.michelson.instructions.base import MichelsonInstruction, format_stdout
 from pytezos.context.abstract import AbstractContext
+from pytezos.crypto.key import Key
+from pytezos.crypto.key import blake2b_32
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import BLS12_381_G1Type
+from pytezos.michelson.types import BLS12_381_G2Type
+from pytezos.michelson.types import BoolType
+from pytezos.michelson.types import BytesType
+from pytezos.michelson.types import KeyHashType
+from pytezos.michelson.types import KeyType
+from pytezos.michelson.types import ListType
+from pytezos.michelson.types import PairType
+from pytezos.michelson.types import SaplingStateType
+from pytezos.michelson.types import SignatureType
 
 
 def execute_hash(prim: str, stack: MichelsonStack, stdout: List[str], hash_digest: Callable[[bytes], bytes]):

--- a/pytezos/michelson/instructions/generic.py
+++ b/pytezos/michelson/instructions/generic.py
@@ -1,10 +1,22 @@
-from typing import List, cast, Union, Tuple
+from typing import List
+from typing import Tuple
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.instructions.base import MichelsonInstruction, dispatch_types, format_stdout
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import StringType, BytesType, ListType, SetType, MapType, NatType, OptionType, UnitType, \
-    NeverType
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import dispatch_types
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import BytesType
+from pytezos.michelson.types import ListType
+from pytezos.michelson.types import MapType
+from pytezos.michelson.types import NatType
+from pytezos.michelson.types import NeverType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import SetType
+from pytezos.michelson.types import StringType
+from pytezos.michelson.types import UnitType
 
 
 class ConcatInstruction(MichelsonInstruction, prim='CONCAT'):

--- a/pytezos/michelson/instructions/stack.py
+++ b/pytezos/michelson/instructions/stack.py
@@ -1,11 +1,15 @@
-from typing import List, Type, cast
+from typing import List
+from typing import Type
+from typing import cast
 
-from pytezos.michelson.micheline import Micheline
-from pytezos.michelson.types import MichelsonType
-from pytezos.michelson.instructions.base import MichelsonInstruction, format_stdout, Wildcard
-from pytezos.michelson.stack import MichelsonStack
 from pytezos.context.abstract import AbstractContext
 from pytezos.michelson.format import micheline_to_michelson
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import Wildcard
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import MichelsonType
 
 
 class PushInstruction(MichelsonInstruction, prim='PUSH', args_len=2):

--- a/pytezos/michelson/instructions/struct.py
+++ b/pytezos/michelson/instructions/struct.py
@@ -1,10 +1,19 @@
-from typing import List, cast, Tuple, Union
+from typing import List
+from typing import Tuple
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.instructions.base import MichelsonInstruction, format_stdout
-from pytezos.michelson.types import MichelsonType, BoolType, ListType, OptionType, \
-    MapType, SetType, BigMapType
-from pytezos.michelson.stack import MichelsonStack
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import BigMapType
+from pytezos.michelson.types import BoolType
+from pytezos.michelson.types import ListType
+from pytezos.michelson.types import MapType
+from pytezos.michelson.types import MichelsonType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import SetType
 
 
 class ConsInstruction(MichelsonInstruction, prim='CONS'):

--- a/pytezos/michelson/instructions/tezos.py
+++ b/pytezos/michelson/instructions/tezos.py
@@ -1,13 +1,27 @@
-from typing import List, cast, Tuple, Optional, Type
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import cast
 
-from pytezos.michelson.instructions.base import format_stdout, MichelsonInstruction
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.micheline import MichelineSequence, MichelsonRuntimeError
-from pytezos.michelson.sections import ParameterSection
-from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.types import NatType, ContractType, AddressType, TimestampType, \
-    OptionType, KeyHashType, UnitType, MutezType, OperationType, ChainIdType
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.michelson.sections import ParameterSection
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import AddressType
+from pytezos.michelson.types import ChainIdType
+from pytezos.michelson.types import ContractType
+from pytezos.michelson.types import KeyHashType
+from pytezos.michelson.types import MutezType
+from pytezos.michelson.types import NatType
+from pytezos.michelson.types import OperationType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import TimestampType
+from pytezos.michelson.types import UnitType
+from pytezos.michelson.types.base import MichelsonType
 
 
 class AmountInstruction(MichelsonInstruction, prim='AMOUNT'):

--- a/pytezos/michelson/instructions/ticket.py
+++ b/pytezos/michelson/instructions/ticket.py
@@ -1,9 +1,16 @@
-from typing import List, cast, Tuple
+from typing import List
+from typing import Tuple
+from typing import cast
 
-from pytezos.michelson.instructions.base import format_stdout, MichelsonInstruction
-from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.types import PairType, TicketType, OptionType, NatType, MichelsonType
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.stack import MichelsonStack
+from pytezos.michelson.types import MichelsonType
+from pytezos.michelson.types import NatType
+from pytezos.michelson.types import OptionType
+from pytezos.michelson.types import PairType
+from pytezos.michelson.types import TicketType
 
 
 class JoinTicketsInstruction(MichelsonInstruction, prim='JOIN_TICKETS'):

--- a/pytezos/michelson/macros.py
+++ b/pytezos/michelson/macros.py
@@ -1,5 +1,5 @@
-import re
 import functools
+import re
 from collections import namedtuple
 from typing import Tuple
 

--- a/pytezos/michelson/micheline.py
+++ b/pytezos/michelson/micheline.py
@@ -1,10 +1,21 @@
-from pprint import pformat
 from functools import wraps
-from typing import Tuple, Dict, Callable, List, Optional, Type, cast, Any, Union
+from pprint import pformat
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
+from pytezos.michelson.forge import unforge_address
+from pytezos.michelson.forge import unforge_chain_id
+from pytezos.michelson.forge import unforge_micheline
+from pytezos.michelson.forge import unforge_public_key
+from pytezos.michelson.forge import unforge_signature
 from pytezos.michelson.format import micheline_to_michelson
-from pytezos.michelson.forge import unforge_chain_id, unforge_address, unforge_public_key, unforge_signature, \
-    unforge_micheline
 from pytezos.michelson.tags import prim_tags
 
 

--- a/pytezos/michelson/parse.py
+++ b/pytezos/michelson/parse.py
@@ -1,8 +1,11 @@
 # Inspired by https://github.com/jansorg/tezos-intellij/blob/master/grammar/michelson.bnf
-from ply.lex import Lexer, lex, LexToken
-from ply.yacc import yacc
-import re
 import json
+import re
+
+from ply.lex import Lexer
+from ply.lex import LexToken
+from ply.lex import lex
+from ply.yacc import yacc
 
 from pytezos.michelson.macros import expand_macro
 

--- a/pytezos/michelson/program.py
+++ b/pytezos/michelson/program.py
@@ -1,13 +1,21 @@
-from typing import Type, List, Tuple, cast, Any
+from typing import Any
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import cast
 
-from pytezos.michelson.sections.parameter import ParameterSection
-from pytezos.michelson.micheline import MichelineSequence, try_catch
-from pytezos.michelson.sections.storage import StorageSection
-from pytezos.michelson.sections.code import CodeSection
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.types import PairType, OperationType, ListType
+from pytezos.michelson.instructions.base import MichelsonInstruction
+from pytezos.michelson.instructions.base import format_stdout
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import try_catch
+from pytezos.michelson.sections.code import CodeSection
+from pytezos.michelson.sections.parameter import ParameterSection
+from pytezos.michelson.sections.storage import StorageSection
 from pytezos.michelson.stack import MichelsonStack
-from pytezos.michelson.instructions.base import format_stdout, MichelsonInstruction
+from pytezos.michelson.types import ListType
+from pytezos.michelson.types import OperationType
+from pytezos.michelson.types import PairType
 
 
 class MichelsonProgram:

--- a/pytezos/michelson/repl.py
+++ b/pytezos/michelson/repl.py
@@ -1,10 +1,14 @@
-from typing import Tuple, List, Optional, Any, cast
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import cast
 
+from pytezos.context.impl import ExecutionContext
 from pytezos.michelson.micheline import MichelsonRuntimeError
 from pytezos.michelson.parse import MichelsonParser
-from pytezos.context.impl import ExecutionContext
-from pytezos.michelson.stack import MichelsonStack
 from pytezos.michelson.program import MichelsonProgram
+from pytezos.michelson.stack import MichelsonStack
 from pytezos.michelson.types import OperationType
 
 

--- a/pytezos/michelson/sections/__init__.py
+++ b/pytezos/michelson/sections/__init__.py
@@ -1,3 +1,3 @@
+from pytezos.michelson.sections.code import CodeSection
 from pytezos.michelson.sections.parameter import ParameterSection
 from pytezos.michelson.sections.storage import StorageSection
-from pytezos.michelson.sections.code import CodeSection

--- a/pytezos/michelson/sections/code.py
+++ b/pytezos/michelson/sections/code.py
@@ -1,7 +1,8 @@
-from typing import List, Type
+from typing import List
+from typing import Type
 
-from pytezos.michelson.micheline import Micheline
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
 
 
 class CodeSection(Micheline, prim='code', args_len=1):

--- a/pytezos/michelson/sections/parameter.py
+++ b/pytezos/michelson/sections/parameter.py
@@ -1,11 +1,19 @@
-from typing import List, Type, cast, Dict, Any, Union, Optional
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Type
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.types.base import MichelsonType, parse_name
-from pytezos.michelson.types import OrType
-from pytezos.michelson.types.core import Unit
-from pytezos.michelson.micheline import Micheline, MichelsonRuntimeError
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.michelson.types import OrType
 from pytezos.michelson.types.adt import wrap_parameters
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import parse_name
+from pytezos.michelson.types.core import Unit
 
 
 class ParameterSection(Micheline, prim='parameter', args_len=1):

--- a/pytezos/michelson/sections/storage.py
+++ b/pytezos/michelson/sections/storage.py
@@ -1,8 +1,10 @@
-from typing import Type, List
+from typing import List
+from typing import Type
 
-from pytezos.michelson.types import *
-from pytezos.michelson.micheline import Micheline, MichelsonRuntimeError
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelsonRuntimeError
+from pytezos.michelson.types import *
 
 
 class StorageSection(Micheline, prim='storage', args_len=1):

--- a/pytezos/michelson/stack.py
+++ b/pytezos/michelson/stack.py
@@ -1,5 +1,7 @@
-from typing import List, Tuple, Optional
 from pprint import pformat
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 from pytezos.michelson.types.base import MichelsonType
 

--- a/pytezos/michelson/types/__init__.py
+++ b/pytezos/michelson/types/__init__.py
@@ -1,15 +1,31 @@
 from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.types.core import IntType, StringType, BoolType, BytesType, UnitType, NatType, NeverType
-from pytezos.michelson.types.domain import AddressType, TimestampType, KeyType, KeyHashType, LambdaType, ContractType, \
-    MutezType, ChainIdType, SignatureType
 from pytezos.michelson.types.big_map import BigMapType
-from pytezos.michelson.types.operation import OperationType
+from pytezos.michelson.types.bls import BLS12_381_FrType
+from pytezos.michelson.types.bls import BLS12_381_G1Type
+from pytezos.michelson.types.bls import BLS12_381_G2Type
+from pytezos.michelson.types.core import BoolType
+from pytezos.michelson.types.core import BytesType
+from pytezos.michelson.types.core import IntType
+from pytezos.michelson.types.core import NatType
+from pytezos.michelson.types.core import NeverType
+from pytezos.michelson.types.core import StringType
+from pytezos.michelson.types.core import UnitType
+from pytezos.michelson.types.domain import AddressType
+from pytezos.michelson.types.domain import ChainIdType
+from pytezos.michelson.types.domain import ContractType
+from pytezos.michelson.types.domain import KeyHashType
+from pytezos.michelson.types.domain import KeyType
+from pytezos.michelson.types.domain import LambdaType
+from pytezos.michelson.types.domain import MutezType
+from pytezos.michelson.types.domain import SignatureType
+from pytezos.michelson.types.domain import TimestampType
 from pytezos.michelson.types.list import ListType
-from pytezos.michelson.types.set import SetType
 from pytezos.michelson.types.map import MapType
+from pytezos.michelson.types.operation import OperationType
 from pytezos.michelson.types.option import OptionType
-from pytezos.michelson.types.sum import OrType
 from pytezos.michelson.types.pair import PairType
-from pytezos.michelson.types.sapling import SaplingStateType, SaplingTransactionType
-from pytezos.michelson.types.bls import BLS12_381_G1Type, BLS12_381_G2Type, BLS12_381_FrType
+from pytezos.michelson.types.sapling import SaplingStateType
+from pytezos.michelson.types.sapling import SaplingTransactionType
+from pytezos.michelson.types.set import SetType
+from pytezos.michelson.types.sum import OrType
 from pytezos.michelson.types.ticket import TicketType

--- a/pytezos/michelson/types/adt.py
+++ b/pytezos/michelson/types/adt.py
@@ -1,6 +1,13 @@
-from typing import List, Tuple, Optional, Dict, Union, Type, Generator
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
 
-from pytezos.michelson.types.base import MichelsonType, Undefined
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import Undefined
 
 
 def get_type_layout(flat_args: List[Tuple[str, Type[MichelsonType]]],

--- a/pytezos/michelson/types/base.py
+++ b/pytezos/michelson/types/base.py
@@ -1,9 +1,17 @@
-from copy import copy, deepcopy
-from typing import Tuple, List, Optional, Type, cast, Union, Any
+from copy import copy
+from copy import deepcopy
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.forge import forge_micheline, unforge_micheline
-from pytezos.michelson.micheline import Micheline
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.forge import forge_micheline
+from pytezos.michelson.forge import unforge_micheline
+from pytezos.michelson.micheline import Micheline
 
 type_mappings = {
     'nat': 'int  /* Natural number */',

--- a/pytezos/michelson/types/big_map.py
+++ b/pytezos/michelson/types/big_map.py
@@ -1,11 +1,22 @@
-from copy import deepcopy, copy
-from typing import Generator, Optional, Tuple, List, Union, Type
+from copy import copy
+from copy import deepcopy
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
 
-from pytezos.michelson.types.base import MichelsonType, Undefined
-from pytezos.michelson.micheline import parse_micheline_literal, Micheline, MichelineLiteral, MichelineSequence
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.types.map import MapType, EltLiteral
 from pytezos.michelson.forge import forge_script_expr
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineLiteral
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import parse_micheline_literal
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import Undefined
+from pytezos.michelson.types.map import EltLiteral
+from pytezos.michelson.types.map import MapType
 
 
 def big_map_diff_to_lazy_diff(big_map_diff: List[dict]):

--- a/pytezos/michelson/types/bls.py
+++ b/pytezos/michelson/types/bls.py
@@ -1,12 +1,15 @@
-from py_ecc import optimized_bls12_381 as bls12_381
-from py_ecc.bls.typing import G1Uncompressed, G2Uncompressed
-from py_ecc.bls.constants import POW_2_382
-from py_ecc.fields import optimized_bls12_381_FQ as FQ, optimized_bls12_381_FQ2 as FQ2
 from typing import cast
 
+from py_ecc import optimized_bls12_381 as bls12_381
+from py_ecc.bls.constants import POW_2_382
+from py_ecc.bls.typing import G1Uncompressed
+from py_ecc.bls.typing import G2Uncompressed
+from py_ecc.fields import optimized_bls12_381_FQ as FQ
+from py_ecc.fields import optimized_bls12_381_FQ2 as FQ2
 
 from pytezos.michelson.micheline import parse_micheline_literal
-from pytezos.michelson.types import IntType, BytesType
+from pytezos.michelson.types import BytesType
+from pytezos.michelson.types import IntType
 
 
 class BLS12_381_FrType(IntType, prim='bls12_381_fr'):

--- a/pytezos/michelson/types/core.py
+++ b/pytezos/michelson/types/core.py
@@ -1,9 +1,12 @@
 from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.micheline import parse_micheline_value, parse_micheline_literal, blind_unpack, Micheline, \
-    MichelineLiteral
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineLiteral
+from pytezos.michelson.micheline import blind_unpack
+from pytezos.michelson.micheline import parse_micheline_literal
+from pytezos.michelson.micheline import parse_micheline_value
+from pytezos.michelson.types.base import MichelsonType
 
 
 class unit(object):

--- a/pytezos/michelson/types/domain.py
+++ b/pytezos/michelson/types/domain.py
@@ -1,16 +1,35 @@
 from decimal import Decimal
-from typing import Type, cast
+from typing import Type
+from typing import cast
 
-from pytezos.crypto.encoding import is_address, is_public_key, is_pkh, is_sig, is_kt, is_chain_id
-from pytezos.michelson.forge import forge_public_key, unforge_public_key, unforge_chain_id, unforge_signature, \
-    forge_address, unforge_address, unforge_contract, forge_base58, optimize_timestamp, forge_contract
-from pytezos.michelson.format import format_timestamp, micheline_to_michelson
-from pytezos.michelson.types.core import NatType, IntType, StringType
-from pytezos.michelson.types.base import MichelsonType, Undefined
+from pytezos.context.abstract import AbstractContext
+from pytezos.context.abstract import get_originated_address
+from pytezos.crypto.encoding import is_address
+from pytezos.crypto.encoding import is_chain_id
+from pytezos.crypto.encoding import is_kt
+from pytezos.crypto.encoding import is_pkh
+from pytezos.crypto.encoding import is_public_key
+from pytezos.crypto.encoding import is_sig
+from pytezos.michelson.forge import forge_address
+from pytezos.michelson.forge import forge_base58
+from pytezos.michelson.forge import forge_contract
+from pytezos.michelson.forge import forge_public_key
+from pytezos.michelson.forge import optimize_timestamp
+from pytezos.michelson.forge import unforge_address
+from pytezos.michelson.forge import unforge_chain_id
+from pytezos.michelson.forge import unforge_contract
+from pytezos.michelson.forge import unforge_public_key
+from pytezos.michelson.forge import unforge_signature
+from pytezos.michelson.format import format_timestamp
+from pytezos.michelson.format import micheline_to_michelson
 from pytezos.michelson.micheline import Micheline
 from pytezos.michelson.micheline import parse_micheline_literal
 from pytezos.michelson.parse import michelson_to_micheline
-from pytezos.context.abstract import AbstractContext, get_originated_address
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import Undefined
+from pytezos.michelson.types.core import IntType
+from pytezos.michelson.types.core import NatType
+from pytezos.michelson.types.core import StringType
 
 
 class TimestampType(IntType, prim='timestamp'):

--- a/pytezos/michelson/types/list.py
+++ b/pytezos/michelson/types/list.py
@@ -1,8 +1,12 @@
-from typing import Tuple, Generator, List, Type
+from typing import Generator
+from typing import List
+from typing import Tuple
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.micheline import Micheline, MichelineSequence
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.types.base import MichelsonType
 
 
 class ListType(MichelsonType, prim='list', args_len=1):

--- a/pytezos/michelson/types/map.py
+++ b/pytezos/michelson/types/map.py
@@ -1,8 +1,14 @@
-from typing import Optional, Tuple, Generator, List, Type
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.micheline import parse_micheline_value, Micheline, MichelineSequence
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import parse_micheline_value
+from pytezos.michelson.types.base import MichelsonType
 
 
 class EltLiteral(Micheline, prim='Elt', args_len=2):

--- a/pytezos/michelson/types/operation.py
+++ b/pytezos/michelson/types/operation.py
@@ -1,7 +1,8 @@
-from typing import Type, Optional
+from typing import Optional
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
 from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.types.base import MichelsonType
 
 
 class OperationType(MichelsonType, prim='operation'):

--- a/pytezos/michelson/types/option.py
+++ b/pytezos/michelson/types/option.py
@@ -1,8 +1,11 @@
-from typing import List, Optional, Type
+from typing import List
+from typing import Optional
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.micheline import parse_micheline_value, Micheline
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import parse_micheline_value
+from pytezos.michelson.types.base import MichelsonType
 
 
 class NoneLiteral(Micheline, prim='None'):

--- a/pytezos/michelson/types/pair.py
+++ b/pytezos/michelson/types/pair.py
@@ -1,9 +1,17 @@
-from typing import Generator, Tuple, List, Union, Type, Optional, cast
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.micheline import Micheline
-from pytezos.michelson.types.base import MichelsonType
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.types.adt import ADTMixin, Nested, wrap_pair
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.types.adt import ADTMixin
+from pytezos.michelson.types.adt import Nested
+from pytezos.michelson.types.adt import wrap_pair
+from pytezos.michelson.types.base import MichelsonType
 
 
 class PairLiteral(Micheline, prim='Pair', args_len=None):

--- a/pytezos/michelson/types/sapling.py
+++ b/pytezos/michelson/types/sapling.py
@@ -1,9 +1,14 @@
 from copy import copy
-from typing import Optional, Type, List
+from typing import List
+from typing import Optional
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
-from pytezos.michelson.micheline import MichelineLiteral, parse_micheline_literal, Micheline, MichelineSequence
 from pytezos.context.abstract import AbstractContext
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineLiteral
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.micheline import parse_micheline_literal
+from pytezos.michelson.types.base import MichelsonType
 
 
 class SaplingTransactionType(MichelsonType, prim='sapling_transaction', args_len=1):

--- a/pytezos/michelson/types/set.py
+++ b/pytezos/michelson/types/set.py
@@ -1,9 +1,12 @@
-from typing import Generator, List, Type
 from copy import copy
+from typing import Generator
+from typing import List
+from typing import Type
 
-from pytezos.michelson.types.base import MichelsonType
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.micheline import Micheline, MichelineSequence
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import MichelineSequence
+from pytezos.michelson.types.base import MichelsonType
 
 
 class SetType(MichelsonType, prim='set', args_len=1):

--- a/pytezos/michelson/types/sum.py
+++ b/pytezos/michelson/types/sum.py
@@ -1,10 +1,22 @@
-from typing import Generator, Tuple, Optional, List, Union, Type, cast
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
-from pytezos.michelson.types.base import MichelsonType, Undefined, undefined
-from pytezos.michelson.micheline import parse_micheline_value, Micheline
 from pytezos.context.abstract import AbstractContext
-from pytezos.michelson.types.adt import ADTMixin, Nested, wrap_or
-from pytezos.michelson.types.core import Unit, UnitType
+from pytezos.michelson.micheline import Micheline
+from pytezos.michelson.micheline import parse_micheline_value
+from pytezos.michelson.types.adt import ADTMixin
+from pytezos.michelson.types.adt import Nested
+from pytezos.michelson.types.adt import wrap_or
+from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.base import Undefined
+from pytezos.michelson.types.base import undefined
+from pytezos.michelson.types.core import Unit
+from pytezos.michelson.types.core import UnitType
 
 
 class LeftLiteral(Micheline, prim='Left', args_len=1):

--- a/pytezos/michelson/types/ticket.py
+++ b/pytezos/michelson/types/ticket.py
@@ -1,13 +1,18 @@
-from typing import List, Type, Optional, Tuple, cast
 from copy import copy
 from pprint import pformat
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import cast
 
+from pytezos.context.abstract import AbstractContext
 from pytezos.michelson.format import micheline_to_michelson
 from pytezos.michelson.micheline import Micheline
 from pytezos.michelson.types.base import MichelsonType
+from pytezos.michelson.types.domain import AddressType
+from pytezos.michelson.types.domain import NatType
 from pytezos.michelson.types.pair import PairType
-from pytezos.michelson.types.domain import NatType, AddressType
-from pytezos.context.abstract import AbstractContext
 
 
 class TicketType(MichelsonType, prim='ticket', args_len=1):

--- a/pytezos/operation/forge.py
+++ b/pytezos/operation/forge.py
@@ -1,5 +1,11 @@
-from pytezos.michelson.forge import forge_micheline, forge_script, forge_nat, forge_public_key, \
-    forge_address, forge_bool, forge_array, forge_base58
+from pytezos.michelson.forge import forge_address
+from pytezos.michelson.forge import forge_array
+from pytezos.michelson.forge import forge_base58
+from pytezos.michelson.forge import forge_bool
+from pytezos.michelson.forge import forge_micheline
+from pytezos.michelson.forge import forge_nat
+from pytezos.michelson.forge import forge_public_key
+from pytezos.michelson.forge import forge_script
 
 operation_tags = {
     'endorsement': 0,

--- a/pytezos/operation/group.py
+++ b/pytezos/operation/group.py
@@ -1,17 +1,23 @@
 from pprint import pformat
-from typing import List, Optional, Any, Dict
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
+from pytezos.context.impl import ExecutionContext  # type: ignore
+from pytezos.context.mixin import ContextMixin  # type: ignore
+from pytezos.crypto.encoding import base58_encode
 from pytezos.crypto.key import blake2b_32
+from pytezos.jupyter import get_class_docstring
+from pytezos.michelson.forge import forge_base58
 from pytezos.operation.content import ContentMixin
+from pytezos.operation.fees import calculate_fee
+from pytezos.operation.fees import default_fee
+from pytezos.operation.fees import default_gas_limit
+from pytezos.operation.fees import default_storage_limit
 from pytezos.operation.forge import forge_operation_group
-from pytezos.operation.fees import calculate_fee, default_fee, default_gas_limit, default_storage_limit
 from pytezos.operation.result import OperationResult
 from pytezos.rpc.errors import RpcError
-from pytezos.crypto.encoding import base58_encode
-from pytezos.michelson.forge import forge_base58
-from pytezos.context.mixin import ContextMixin  # type: ignore
-from pytezos.context.impl import ExecutionContext  # type: ignore
-from pytezos.jupyter import get_class_docstring
 
 DEFAULT_GAS_RESERVE = 100
 DEFAULT_BRANCH_OFFSET = 50
@@ -46,7 +52,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         branch: Optional[str] = None,
         signature: Optional[str] = None,
     ):
-        super(OperationGroup, self).__init__(context=context)
+        super().__init__(context=context)
         self.contents = contents or []
         self.protocol = protocol
         self.chain_id = chain_id
@@ -55,7 +61,7 @@ class OperationGroup(ContextMixin, ContentMixin):
 
     def __repr__(self):
         res = [
-            super(OperationGroup, self).__repr__(),
+            super().__repr__(),
             '\nPayload',
             pformat(self.json_payload()),
             '\nHelpers',
@@ -107,7 +113,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         :param branch_offset: select head~offset block as branch, where offset is in range (0, 60)
         :rtype: OperationGroup
         """
-        assert 0 < branch_offset < 60, f'branch offset has to be in range (0, 60)'
+        assert 0 < branch_offset < 60, 'branch offset has to be in range (0, 60)'
         chain_id = self.chain_id or self.context.get_chain_id()
         branch = self.branch or self.shell.blocks[-branch_offset].hash()
         protocol = self.protocol or self.shell.head.header()['protocol']
@@ -192,8 +198,10 @@ class OperationGroup(ContextMixin, ContentMixin):
         :param counter: Override counter value (for manual handling)
         :param branch_offset: Select head~offset block as branch, where offset is in range (0, 60)
         :param fee: Explicitly set fee for operation. If not set fee will be calculated depeding on results of operation dry-run.
-        :param gas_limit: Explicitly set gas limit for operation. If not set gas limit will be calculated depeding on results of operation dry-run.
-        :param storage_limit: Explicitly set storage limit for operation. If not set storage limit will be calculated depeding on results of operation dry-run.
+        :param gas_limit: Explicitly set gas limit for operation. If not set gas limit will be calculated depeding on results of
+            operation dry-run.
+        :param storage_limit: Explicitly set storage limit for operation. If not set storage limit will be calculated depeding on
+            results of operation dry-run.
         :rtype: OperationGroup
         """
         opg = self.fill(counter=counter, branch_offset=branch_offset)
@@ -295,20 +303,20 @@ class OperationGroup(ContextMixin, ContentMixin):
                 'hash': opg_hash,
                 **self.json_payload()
             }
-        else:
-            for i in range(num_blocks_wait):
-                self.shell.wait_next_block(time_between_blocks=time_between_blocks)
-                try:
-                    pending_opg = self.shell.mempool.pending_operations[opg_hash]
-                    if not OperationResult.is_applied(pending_opg):
-                        raise RpcError.from_errors(OperationResult.errors(pending_opg))
-                    print(f'Still in mempool: {opg_hash}')
-                except StopIteration:
-                    res = self.shell.blocks[-(i + 1):].find_operation(opg_hash)
-                    if check_result:
-                        if not OperationResult.is_applied(res):
-                            raise RpcError.from_errors(OperationResult.errors(res))
-                    return res
+
+        for i in range(num_blocks_wait):
+            self.shell.wait_next_block(time_between_blocks=time_between_blocks)
+            try:
+                pending_opg = self.shell.mempool.pending_operations[opg_hash]
+                if not OperationResult.is_applied(pending_opg):
+                    raise RpcError.from_errors(OperationResult.errors(pending_opg))
+                print(f'Still in mempool: {opg_hash}')
+            except StopIteration as exc:
+                res = self.shell.blocks[-(i + 1):].find_operation(opg_hash)
+                if check_result:
+                    if not OperationResult.is_applied(res):
+                        raise RpcError.from_errors(OperationResult.errors(res)) from exc
+                return res
 
         raise TimeoutError(opg_hash)
 

--- a/pytezos/operation/result.py
+++ b/pytezos/operation/result.py
@@ -1,6 +1,7 @@
 import functools
 import operator
 from typing import List
+
 from pytezos.rpc.errors import RpcError
 
 

--- a/pytezos/protocol/diff.py
+++ b/pytezos/protocol/diff.py
@@ -1,7 +1,9 @@
-import re
 import difflib
+import re
+from os.path import dirname
+from os.path import join
+
 import simplejson as json
-from os.path import dirname, join
 
 # Based on https://gist.github.com/noporpoise/16e731849eb1231e86d78f9dfeca3abc
 _no_eol = r'\ No newline at end of file'

--- a/pytezos/protocol/protocol.py
+++ b/pytezos/protocol/protocol.py
@@ -1,19 +1,24 @@
 import io
 import os
 import tarfile
+from binascii import hexlify
+from collections import OrderedDict
+from tempfile import TemporaryDirectory
+from typing import List
+from typing import Tuple
+
 import netstruct
 import requests
 import simplejson as json
 from tqdm import tqdm
-from binascii import hexlify
-from collections import OrderedDict
-from tempfile import TemporaryDirectory
-from typing import List, Tuple
 
-from pytezos.crypto.key import blake2b_32
 from pytezos.crypto.encoding import base58_encode
-from pytezos.protocol.diff import make_patch, apply_patch, generate_unidiff_html
-from pytezos.jupyter import get_class_docstring, InlineDocstring
+from pytezos.crypto.key import blake2b_32
+from pytezos.jupyter import InlineDocstring
+from pytezos.jupyter import get_class_docstring
+from pytezos.protocol.diff import apply_patch
+from pytezos.protocol.diff import generate_unidiff_html
+from pytezos.protocol.diff import make_patch
 
 
 def dir_to_files(path) -> List[Tuple[str, str]]:

--- a/pytezos/rpc/__init__.py
+++ b/pytezos/rpc/__init__.py
@@ -1,5 +1,6 @@
-from pytezos.rpc.shell import *
-from pytezos.rpc.protocol import *
 from pytezos.rpc.helpers import *
+from pytezos.rpc.node import RpcMultiNode
+from pytezos.rpc.node import RpcNode
+from pytezos.rpc.protocol import *
 from pytezos.rpc.search import *
-from pytezos.rpc.node import RpcNode, RpcMultiNode
+from pytezos.rpc.shell import *

--- a/pytezos/rpc/node.py
+++ b/pytezos/rpc/node.py
@@ -1,6 +1,7 @@
+from pprint import pformat
+
 import requests
 from simplejson import JSONDecodeError
-from pprint import pformat
 
 
 def urljoin(*args):

--- a/pytezos/rpc/protocol.py
+++ b/pytezos/rpc/protocol.py
@@ -1,14 +1,16 @@
-import pendulum
-import bson
-from pendulum.parsing.exceptions import ParserError
 from datetime import datetime
 from itertools import count
 from typing import Iterator
 
+import bson
+import pendulum
+from pendulum.parsing.exceptions import ParserError
+
+from pytezos.crypto.encoding import is_bh
+from pytezos.crypto.encoding import is_ogh
 from pytezos.jupyter import get_attr_docstring
-from pytezos.rpc.search import BlockSliceQuery
 from pytezos.rpc.query import RpcQuery
-from pytezos.crypto.encoding import is_bh, is_ogh
+from pytezos.rpc.search import BlockSliceQuery
 
 
 def to_timestamp(v):

--- a/pytezos/rpc/query.py
+++ b/pytezos/rpc/query.py
@@ -1,8 +1,10 @@
 from os.path import dirname
 
-from pytezos.rpc.node import RpcNode
+from pytezos.jupyter import InlineDocstring
+from pytezos.jupyter import get_attr_docstring
+from pytezos.jupyter import get_class_docstring
 from pytezos.rpc.docs import rpc_docs
-from pytezos.jupyter import get_attr_docstring, get_class_docstring, InlineDocstring
+from pytezos.rpc.node import RpcNode
 
 
 def format_docstring(class_type, query_path):

--- a/pytezos/rpc/search.py
+++ b/pytezos/rpc/search.py
@@ -1,10 +1,13 @@
-from typing import Any, Callable, Generator
+from typing import Any
+from typing import Callable
+from typing import Generator
+
 from loguru import logger
 
+from pytezos.crypto.encoding import is_bh
+from pytezos.jupyter import get_attr_docstring
 from pytezos.rpc.node import RpcError
 from pytezos.rpc.query import RpcQuery
-from pytezos.jupyter import get_attr_docstring
-from pytezos.crypto.encoding import is_bh
 
 
 def find_state_change_intervals(head: int, last: int, get: Callable, equals: Callable,

--- a/pytezos/rpc/shell.py
+++ b/pytezos/rpc/shell.py
@@ -1,15 +1,17 @@
-import requests
-import simplejson as json
-from typing import Optional
-from functools import lru_cache
 from binascii import hexlify
 from datetime import datetime
+from functools import lru_cache
 from time import sleep
+from typing import Optional
+
+import requests
+import simplejson as json
 
 from pytezos.crypto.encoding import base58_decode
-from pytezos.rpc.query import RpcQuery
 from pytezos.jupyter import get_attr_docstring
-from pytezos.rpc.search import CyclesQuery, VotingPeriodsQuery
+from pytezos.rpc.query import RpcQuery
+from pytezos.rpc.search import CyclesQuery
+from pytezos.rpc.search import VotingPeriodsQuery
 
 
 def make_operation_result(**kwargs):


### PR DESCRIPTION
Add `isort` and `pylint` to CI workflow. Fatal pylint messages will fail pipeline which is pretty useful in mitigation typos.