### PR TITLE
Update retry logic to reduce timeouts

### DIFF
--- a/src/pytezos/operation/group.py
+++ b/src/pytezos/operation/group.py
@@ -340,6 +340,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         :param num_blocks_wait: number of blocks to wait for injection
         :param time_between_blocks: override the corresponding parameter from constants
         :param min_confirmations: number of block injections to wait for before returning
+        :param kwargs: additional keyword arguments to pass to self.shell.wait_next_block
         :returns: operation group with metadata (raw RPC response)
         """
         self.context.reset()
@@ -361,7 +362,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         confirmations = 0
         for _ in range(num_blocks_wait):
             logger.info('Waiting for the next block')
-            self.shell.wait_next_block(time_between_blocks=time_between_blocks)
+            self.shell.wait_next_block(time_between_blocks=time_between_blocks, **kwargs)
 
             if in_mempool:
                 try:

--- a/src/pytezos/rpc/node.py
+++ b/src/pytezos/rpc/node.py
@@ -22,7 +22,7 @@ def _retry(fn: Callable, backoff=2):
             logger.debug('Node request attempt %s/%s', attempt, REQUEST_RETRY_COUNT)
             try:
                 return fn(*args, **kwargs)
-            except requests.exceptions.ConnectionError as e:
+            except (requests.exceptions.ConnectionError, RpcError) as e:
                 if attempt >= REQUEST_RETRY_COUNT:
                     raise e
                 logger.warning(e)

--- a/src/pytezos/rpc/node.py
+++ b/src/pytezos/rpc/node.py
@@ -10,7 +10,7 @@ from simplejson import JSONDecodeError
 
 from pytezos.logging import logger
 
-REQUEST_RETRY_COUNT = 3
+REQUEST_RETRY_COUNT = 5
 REQUEST_RETRY_SLEEP = 1
 
 

--- a/src/pytezos/rpc/node.py
+++ b/src/pytezos/rpc/node.py
@@ -14,18 +14,20 @@ REQUEST_RETRY_COUNT = 3
 REQUEST_RETRY_SLEEP = 1
 
 
-def _retry(fn: Callable):
+def _retry(fn: Callable, backoff=2):
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        for attempt in range(REQUEST_RETRY_COUNT):
-            logger.debug('Node request attempt %s/%s', attempt + 1, REQUEST_RETRY_COUNT)
+        delay = REQUEST_RETRY_SLEEP
+        for attempt in range(1, REQUEST_RETRY_COUNT + 1):
+            logger.debug('Node request attempt %s/%s', attempt, REQUEST_RETRY_COUNT)
             try:
                 return fn(*args, **kwargs)
             except requests.exceptions.ConnectionError as e:
-                if attempt + 1 == REQUEST_RETRY_COUNT:
+                if attempt >= REQUEST_RETRY_COUNT:
                     raise e
                 logger.warning(e)
-                time.sleep(REQUEST_RETRY_SLEEP)
+                time.sleep(delay)
+                delay *= backoff
 
     return wrapper
 


### PR DESCRIPTION
Hi pytezos team! We're using pytezos for orchestrating deployments and tests for [checker](https://github.com/tezos-checker/checker) and ran into some timeout issues when working with remote nodes such as `https://testnet-tezos.giganode.io`. In testing we found that the current retry logic often resulted in timeouts since there is some latency between when RPCs return and when nodes expose data like block hashes. To address this issue, this PR adds backoff to the retry decorator in `pytezos.rpc.node` and slightly increases the number of retry attempts. It also enables users to specify additional keyword arguments to `wait_next_block` when calling inject() to allow for greater control of retry attempts there. 

Thanks and please let me know if you have any questions.