### PR TITLE
Change NotImplementedError to ImportError when missing C libs.

### DIFF
--- a/src/pytezos/crypto/key.py
+++ b/src/pytezos/crypto/key.py
@@ -35,7 +35,7 @@ def get_passphrase(passphrase: PassphraseInput = None, alias: Optional[str] = No
 
 class CryptoExtraFallback:
     def __getattr__(self, item):
-        raise NotImplementedError(
+        raise ImportError(
             "Please, install packages libsodium-dev, libsecp256k1-dev, and libgmp-dev, "
             "and Python libraries pysodium, secp256k1, and fastecdsa"
         )


### PR DESCRIPTION
We do this because this error is discovered at import time and
represents a failure to import the module rather than a missing
feature.