### PR TITLE
Fix incorrect pair type comparison

### DIFF
--- a/src/pytezos/michelson/types/pair.py
+++ b/src/pytezos/michelson/types/pair.py
@@ -24,9 +24,9 @@ class PairType(MichelsonType, ADTMixin, prim='pair', args_len=None):
 
     def __lt__(self, other: 'PairType'):  # type: ignore
         for i, item in enumerate(self.items):
-            if item < other.items[i]:
-                return True
-        return False
+            if item > other.items[i]:
+                return False
+        return True
 
     def __hash__(self):
         return hash(self.items)


### PR DESCRIPTION
For some of my project calls the interpreter failed with `set is not sorted` error for `set` containing pairs of type `address * nat`. This fix helped me and it seems logical: before it assumed if earlier element is smaller it immediately considers whole pair as smaller. Where as now it makes sure every item is actually less than or equal to the other one to be sure whole pair is smaller.