### PR TITLE
Protecting against undefined secondary block delay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytezos"
-version = "3.2.6"
+version = "3.2.7"
 description = "Python toolkit for Tezos"
 license = "MIT"
 authors = ["Michael Zaikin <mz@baking-bad.org>", "Arthur Breitman", "Roman Serikov"]

--- a/src/pytezos/rpc/shell.py
+++ b/src/pytezos/rpc/shell.py
@@ -83,7 +83,7 @@ class ShellQuery(RpcQuery, path=''):
             block_delay, secondary_delay = time_between_blocks, 0
         else:
             tbb = self.blocks[current_block_hash].context.constants()["time_between_blocks"]
-            block_delay, secondary_delay = int(tbb[0]), int(tbb[1])
+            block_delay, secondary_delay = int(tbb[0]), 0 if len(tbb) == 1 else int(tbb[1])
 
         if yield_current:
             yield current_block_hash


### PR DESCRIPTION
When running the flextesa sandbox (through bcdhub) and calling `alice_client.wait(num_blocks_wait=1)`, an exception was being thrown here, since `tbb` only had one value (`tbb = ['4']`).