### PR TITLE
Ensure that run_view output matches its declared return type

### DIFF
--- a/src/pytezos/michelson/repl.py
+++ b/src/pytezos/michelson/repl.py
@@ -158,6 +158,13 @@ class Interpreter:
             _, _, _, pair = res.end(stack, stdout)
             operations = cast(List[OperationType], list(pair.items[0]))
             storage = pair.items[1]
+            # Note: the `storage` returned by the Michelson interpreter above is not
+            # required to include the full annotations specified in the contract's storage.
+            # The lack of annotations affects calls to `to_python_object()`, causing the storage
+            # you get back from the view to not always be converted to the same object
+            # as if you called ContractInterface.storage() directly.
+            # Re-parsing using the contract's storage section here to recover the annotations.
+            storage = program.storage.from_micheline_value(storage.to_micheline_value())
             return [op.to_python_object() for op in operations], storage.to_python_object(), stdout, None
         except MichelsonRuntimeError as e:
             stdout.append(e.format_stdout())

--- a/src/pytezos/operation/group.py
+++ b/src/pytezos/operation/group.py
@@ -33,7 +33,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         branch: Optional[str] = None,
         signature: Optional[str] = None,
         opg_hash: Optional[str] = None,
-        opg_result: Optional[Dict[str, Any]] = None
+        opg_result: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(context=context)
         self.contents = contents or []

--- a/tests/unit_tests/test_michelson/test_repl/test_view.py
+++ b/tests/unit_tests/test_michelson/test_repl/test_view.py
@@ -1,0 +1,89 @@
+import json
+from unittest.case import TestCase
+from unittest.mock import MagicMock
+
+from pytezos.contract.interface import ContractInterface
+from pytezos.contract.metadata import ContractMetadata
+from pytezos.michelson.types.core import UnitType
+
+TEST_VIEW_CONTRACT_MICHELSON = """
+{ parameter unit ; storage unit ; code { CDR ; NIL operation ; PAIR } }
+"""
+
+TEST_VIEW_JSON = """
+{
+    "name": "my-simple-contract-metadata",
+    "description": "This is fake metadata to use for unit testing",
+    "version": "0.42.0",
+    "license": {
+      "name": "MIT",
+      "details": "The MIT License"
+    },
+    "homepage": "https://gitlab.com/tezos/tezos",
+    "interfaces": [
+      "TZIP-16",
+      "TZIP-12"
+    ],
+    "views": [
+        {
+            "name": "view_record_like",
+            "implementations": [
+                {
+                    "michelsonStorageView": {
+                        "parameter": {
+                            "prim": "unit"
+                        },
+                        "returnType": {
+                           "prim": "pair",
+                            "args":
+                              [ { "prim": "pair",
+                                  "args":
+                                    [ { "prim": "pair",
+                                        "args": [ { "prim": "int" }, { "prim": "nat" } ],
+                                        "annots": [ "%a_plain_tuple" ] },
+                                      { "prim": "nat", "annots": [ "%my_first_nat" ] } ] },
+                                { "prim": "pair",
+                                  "args":
+                                    [ { "prim": "int", "annots": [ "%my_first_number" ] },
+                                      { "prim": "int", "annots": [ "%my_second_number" ] } ] }
+                              ]
+                        },
+                        "code": [
+                          { "prim": "DROP" },
+                          { "prim": "PUSH", "args": [ { "prim": "int" }, { "int": "42" } ] },
+                          { "prim": "ISNAT" },
+                          { "prim": "IF_NONE",
+                            "args":
+                              [ [ { "prim": "PUSH",
+                                    "args": [ { "prim": "string" }, { "string": "FAILURE" } ] },
+                                  { "prim": "FAILWITH" } ], [] ] },
+                          { "prim": "PUSH", "args": [ { "prim": "int" }, { "int": "2" } ] },
+                          { "prim": "PUSH", "args": [ { "prim": "int" }, { "int": "1" } ] },
+                          { "prim": "PAIR" }, { "prim": "SWAP" }, { "prim": "DUP" },
+                          { "prim": "PUSH", "args": [ { "prim": "int" }, { "int": "3" } ] },
+                          { "prim": "PAIR" }, { "prim": "PAIR" }, { "prim": "PAIR" }
+                      ]
+                    }
+                }
+            ]
+      }
+    ]
+}
+"""
+
+
+class OffchainViewTest(TestCase):
+    def test_view_return_type_regression_251(self) -> None:
+        # Need to mock the shell for unit testing. Configuring it to always return a simple
+        # value for the contract's current storage state
+        mock_shell = MagicMock()
+        mock_shell.blocks.__getitem__.return_value.context.contracts.__getitem__.return_value.storage.return_value = (
+            UnitType().to_micheline_value()
+        )
+        contract = ContractInterface.from_michelson(TEST_VIEW_CONTRACT_MICHELSON)
+        contract.context.shell = mock_shell
+        meta = ContractMetadata.from_json(json.loads(TEST_VIEW_JSON), contract.context)
+
+        expected_view_result = {"my_first_number": 1, "my_first_nat": 42, "my_second_number": 2, "a_plain_tuple": (3, 42)}
+        actual_view_result = meta.viewRecordLike().storage_view()
+        assert expected_view_result == actual_view_result, f"Expected: {expected_view_result} but got: {actual_view_result}"


### PR DESCRIPTION
This PR addresses #251 by adding some internal logic to `Interpreter.run_view` which re-parses the Micheline object you get back from the repl using the "storage" object which corresponds to the view's `returnType`. This is necessary because the Michelson interpreter returns a storage state which does not include the annotations present in a contract's storage section, causing the call to `to_python_object()` to return unexpected values (e.g. tuples instead of dicts for named values). Not returning annotations does seems to match the behavior of the main tezos interpreter though. Also added a regression test to go along with this change.