### PR TITLE
Lazy evaluation of big_maps for encoding / decoding Michelson storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytezos"
-version = "3.2.10"
+version = "3.2.11"
 description = "Python toolkit for Tezos"
 license = "MIT"
 authors = ["Michael Zaikin <mz@baking-bad.org>", "Arthur Breitman", "Roman Serikov"]

--- a/src/pytezos/contract/data.py
+++ b/src/pytezos/contract/data.py
@@ -52,7 +52,7 @@ class ContractData(ContextMixin):
 
         :param optimized: use optimized data form for some domain types (timestamp, address, etc.)
         """
-        return self.data.to_micheline_value(mode='optimized' if optimized else 'readable')
+        return self.data.to_micheline_value(mode='optimized' if optimized else 'readable', lazy_diff=True)
 
     def to_michelson(self, optimized=False):
         """Get as Michelson value
@@ -62,23 +62,24 @@ class ContractData(ContextMixin):
         return micheline_to_michelson(self.to_micheline(optimized=optimized))
 
     def decode(self, value):
-        """Convert from Michelson to Python type system
+        """Convert from Michelson or Micheline to Python type system
 
         :param value: Micheline JSON expression or Michelson value
         :return: Python object
         """
         if isinstance(value, str):
             value = michelson_to_micheline(value)
-        return type(self.data).from_micheline_value(value).to_python_object()
+        return type(self.data).from_micheline_value(value).to_python_object(lazy_diff=True)
 
     def encode(self, py_obj, mode: Optional[str] = None):
-        """Convert from Python to Michelson type system
+        """Convert from Python to Micheline type system
 
         :param py_obj: Python object
         :param mode: whether to use `readable` or `optimized` (or `legacy_optimized`) encoding
         :return: Micheline JSON expression
         """
-        return type(self.data).from_python_object(py_obj).to_micheline_value(mode=mode or self.context.mode)
+        return type(self.data).from_python_object(py_obj).to_micheline_value(mode=mode or self.context.mode,
+                                                                             lazy_diff=True)
 
     def dummy(self):
         """Try to generate a dummy (empty) value

--- a/tests/unit_tests/test_contract/contracts/contract_for_data_conversion_test.tz
+++ b/tests/unit_tests/test_contract/contracts/contract_for_data_conversion_test.tz
@@ -1,0 +1,507 @@
+{ parameter
+    (or (or (or %admin (or (unit %confirm_admin) (bool %pause)) (address %set_admin))
+            (or %assets
+               (or (pair %balance_of
+                      (list %requests (pair (address %owner) (nat %token_id)))
+                      (contract %callback
+                         (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))))
+                   (list %transfer
+                      (pair (address %from_)
+                            (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))))
+               (list %update_operators
+                  (or (pair %add_operator (address %owner) (pair (address %operator) (nat %token_id)))
+                      (pair %remove_operator (address %owner) (pair (address %operator) (nat %token_id)))))))
+        (list %mint
+           (pair (pair %token_metadata (nat %token_id) (map %token_info string bytes))
+                 (address %owner)))) ;
+  storage
+    (pair (pair (pair %admin (pair (address %admin) (bool %paused)) (option %pending_admin address))
+                (pair %assets
+                   (pair (big_map %ledger nat address) (nat %next_token_id))
+                   (pair (big_map %operators (pair address (pair address nat)) unit)
+                         (big_map %token_metadata nat (pair (nat %token_id) (map %token_info string bytes))))))
+          (big_map %metadata string bytes)) ;
+  code { LAMBDA
+           (pair (pair address bool) (option address))
+           unit
+           { CAR ;
+             CAR ;
+             SENDER ;
+             COMPARE ;
+             NEQ ;
+             IF { PUSH string "NOT_AN_ADMIN" ; FAILWITH } { UNIT } } ;
+         PUSH string "FA2_TOKEN_UNDEFINED" ;
+         PUSH string "FA2_INSUFFICIENT_BALANCE" ;
+         SWAP ;
+         DUP ;
+         DUG 2 ;
+         SWAP ;
+         PAIR ;
+         LAMBDA
+           (pair (pair string string)
+                 (pair (pair (list (pair (option address) (list (pair (option address) (pair nat nat)))))
+                             (lambda
+                                (pair (pair address address) (pair nat (big_map (pair address (pair address nat)) unit)))
+                                unit))
+                       (pair (pair (big_map nat address) nat)
+                             (pair (big_map (pair address (pair address nat)) unit)
+                                   (big_map nat (pair nat (map string bytes)))))))
+           (pair (list operation)
+                 (pair (pair (big_map nat address) nat)
+                       (pair (big_map (pair address (pair address nat)) unit)
+                             (big_map nat (pair nat (map string bytes))))))
+           { UNPAIR ;
+             UNPAIR ;
+             DIG 2 ;
+             UNPAIR ;
+             UNPAIR ;
+             DUP 3 ;
+             CAR ;
+             CAR ;
+             DUP 4 ;
+             CDR ;
+             CAR ;
+             PAIR ;
+             DUG 2 ;
+             DUP ;
+             DUG 3 ;
+             DIG 2 ;
+             UNPAIR ;
+             SWAP ;
+             DIG 2 ;
+             ITER { DUP ;
+                    DUG 2 ;
+                    CDR ;
+                    ITER { SWAP ;
+                           DUP 3 ;
+                           CAR ;
+                           IF_NONE
+                             { UNIT }
+                             { DUP 5 ;
+                               DUP 4 ;
+                               GET 3 ;
+                               PAIR ;
+                               SENDER ;
+                               DIG 2 ;
+                               PAIR ;
+                               PAIR ;
+                               DUP 6 ;
+                               SWAP ;
+                               EXEC } ;
+                           DROP ;
+                           PUSH nat 1 ;
+                           DUP 3 ;
+                           GET 4 ;
+                           COMPARE ;
+                           GT ;
+                           IF { DROP 2 ; DUP 6 ; FAILWITH }
+                              { PUSH nat 0 ;
+                                DUP 3 ;
+                                GET 4 ;
+                                COMPARE ;
+                                EQ ;
+                                IF { DUP ;
+                                     DIG 2 ;
+                                     GET 3 ;
+                                     GET ;
+                                     IF_NONE { DROP ; DUP 7 ; FAILWITH } { DROP } }
+                                   { SWAP ;
+                                     DUP ;
+                                     DUG 2 ;
+                                     GET 3 ;
+                                     DUP 4 ;
+                                     CAR ;
+                                     IF_NONE
+                                       { DROP }
+                                       { DUP 3 ;
+                                         DUP 3 ;
+                                         GET ;
+                                         IF_NONE
+                                           { DROP 3 ; DUP 8 ; FAILWITH }
+                                           { COMPARE ;
+                                             EQ ;
+                                             IF { NONE address ; SWAP ; UPDATE } { DROP 2 ; DUP 7 ; FAILWITH } } } ;
+                                     SWAP ;
+                                     DUP ;
+                                     DUG 2 ;
+                                     GET 3 ;
+                                     DIG 2 ;
+                                     CAR ;
+                                     IF_NONE { DROP } { DIG 2 ; SWAP ; DIG 2 ; SWAP ; SOME ; SWAP ; UPDATE } } } } ;
+                    SWAP ;
+                    DROP } ;
+             SWAP ;
+             DIG 2 ;
+             DIG 5 ;
+             DIG 6 ;
+             DROP 4 ;
+             DUP 3 ;
+             CDR ;
+             DUP 4 ;
+             CAR ;
+             CDR ;
+             DIG 2 ;
+             PAIR ;
+             PAIR ;
+             DUG 2 ;
+             DROP 2 ;
+             NIL operation ;
+             PAIR } ;
+         SWAP ;
+         APPLY ;
+         DIG 3 ;
+         UNPAIR ;
+         IF_LEFT
+           { IF_LEFT
+               { DIG 2 ;
+                 DIG 3 ;
+                 DROP 2 ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CAR ;
+                 CAR ;
+                 SWAP ;
+                 IF_LEFT
+                   { IF_LEFT
+                       { DIG 3 ;
+                         DROP 2 ;
+                         DUP ;
+                         CDR ;
+                         IF_NONE
+                           { DROP ; PUSH string "NO_PENDING_ADMIN" ; FAILWITH }
+                           { SENDER ;
+                             COMPARE ;
+                             EQ ;
+                             IF { NONE address ; SWAP ; CAR ; CDR ; SENDER ; PAIR ; PAIR }
+                                { DROP ; PUSH string "NOT_A_PENDING_ADMIN" ; FAILWITH } } ;
+                         NIL operation ;
+                         PAIR }
+                       { SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         DIG 4 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         CDR ;
+                         SWAP ;
+                         DIG 2 ;
+                         CAR ;
+                         CAR ;
+                         PAIR ;
+                         PAIR ;
+                         NIL operation ;
+                         PAIR } }
+                   { SWAP ;
+                     DUP ;
+                     DUG 2 ;
+                     DIG 4 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     SOME ;
+                     SWAP ;
+                     CAR ;
+                     PAIR ;
+                     NIL operation ;
+                     PAIR } ;
+                 UNPAIR ;
+                 DUP 3 ;
+                 CDR ;
+                 DIG 3 ;
+                 CAR ;
+                 CDR ;
+                 DIG 3 ;
+                 PAIR ;
+                 PAIR ;
+                 SWAP ;
+                 PAIR }
+               { DIG 4 ;
+                 DROP ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CAR ;
+                 CAR ;
+                 CAR ;
+                 CDR ;
+                 IF { PUSH string "PAUSED" ; FAILWITH } {} ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CAR ;
+                 CDR ;
+                 SWAP ;
+                 IF_LEFT
+                   { IF_LEFT
+                       { DIG 3 ;
+                         DROP ;
+                         SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         CAR ;
+                         CAR ;
+                         SWAP ;
+                         DUP ;
+                         CAR ;
+                         MAP { DUP 3 ;
+                               SWAP ;
+                               DUP ;
+                               DUG 2 ;
+                               CDR ;
+                               GET ;
+                               IF_NONE
+                                 { DROP ; DUP 5 ; FAILWITH }
+                                 { SWAP ;
+                                   DUP ;
+                                   CAR ;
+                                   DIG 2 ;
+                                   COMPARE ;
+                                   EQ ;
+                                   IF { PUSH nat 1 } { PUSH nat 0 } ;
+                                   SWAP ;
+                                   PAIR } } ;
+                         DIG 2 ;
+                         DIG 5 ;
+                         DROP 2 ;
+                         SWAP ;
+                         CDR ;
+                         PUSH mutez 0 ;
+                         DIG 2 ;
+                         TRANSFER_TOKENS ;
+                         SWAP ;
+                         NIL operation ;
+                         DIG 2 ;
+                         CONS ;
+                         PAIR }
+                       { DIG 4 ;
+                         DROP ;
+                         MAP { DUP ;
+                               CDR ;
+                               MAP { DUP ;
+                                     CAR ;
+                                     SOME ;
+                                     SWAP ;
+                                     DUP ;
+                                     DUG 2 ;
+                                     GET 3 ;
+                                     DIG 2 ;
+                                     GET 4 ;
+                                     SWAP ;
+                                     PAIR ;
+                                     SWAP ;
+                                     PAIR } ;
+                               SWAP ;
+                               CAR ;
+                               SOME ;
+                               PAIR } ;
+                         SWAP ;
+                         LAMBDA
+                           (pair (pair address address) (pair nat (big_map (pair address (pair address nat)) unit)))
+                           unit
+                           { UNPAIR ;
+                             UNPAIR ;
+                             DIG 2 ;
+                             UNPAIR ;
+                             DUP 4 ;
+                             DUP 4 ;
+                             COMPARE ;
+                             EQ ;
+                             IF { DROP 4 ; UNIT }
+                                { DIG 3 ;
+                                  PAIR ;
+                                  DIG 2 ;
+                                  PAIR ;
+                                  MEM ;
+                                  IF { UNIT } { PUSH string "FA2_NOT_OPERATOR" ; FAILWITH } } } ;
+                         DIG 2 ;
+                         PAIR ;
+                         PAIR ;
+                         DIG 2 ;
+                         SWAP ;
+                         EXEC } }
+                   { DIG 3 ;
+                     DIG 4 ;
+                     DROP 2 ;
+                     SWAP ;
+                     DUP ;
+                     DUG 2 ;
+                     CDR ;
+                     CAR ;
+                     SWAP ;
+                     SENDER ;
+                     DUG 2 ;
+                     ITER { SWAP ;
+                            DUP 3 ;
+                            DUP 3 ;
+                            IF_LEFT {} {} ;
+                            CAR ;
+                            COMPARE ;
+                            EQ ;
+                            IF {} { PUSH string "FA2_NOT_OWNER" ; FAILWITH } ;
+                            SWAP ;
+                            IF_LEFT
+                              { SWAP ;
+                                UNIT ;
+                                SOME ;
+                                DUP 3 ;
+                                GET 4 ;
+                                DUP 4 ;
+                                GET 3 ;
+                                PAIR ;
+                                DIG 3 ;
+                                CAR ;
+                                PAIR ;
+                                UPDATE }
+                              { DUP ;
+                                DUG 2 ;
+                                GET 4 ;
+                                DUP 3 ;
+                                GET 3 ;
+                                PAIR ;
+                                DIG 2 ;
+                                CAR ;
+                                PAIR ;
+                                NONE unit ;
+                                SWAP ;
+                                UPDATE } } ;
+                     SWAP ;
+                     DROP ;
+                     SWAP ;
+                     DUP ;
+                     DUG 2 ;
+                     CDR ;
+                     CDR ;
+                     SWAP ;
+                     PAIR ;
+                     SWAP ;
+                     CAR ;
+                     PAIR ;
+                     NIL operation ;
+                     PAIR } ;
+                 UNPAIR ;
+                 DUP 3 ;
+                 CDR ;
+                 DIG 2 ;
+                 DIG 3 ;
+                 CAR ;
+                 CAR ;
+                 PAIR ;
+                 PAIR ;
+                 SWAP ;
+                 PAIR } }
+           { DIG 3 ;
+             DROP ;
+             SWAP ;
+             DUP ;
+             DUG 2 ;
+             CAR ;
+             CAR ;
+             DIG 4 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             SWAP ;
+             DUP ;
+             DUG 2 ;
+             CAR ;
+             CDR ;
+             NIL (pair (option address) (pair nat nat)) ;
+             PAIR ;
+             SWAP ;
+             ITER { DUP ;
+                    DUG 2 ;
+                    CAR ;
+                    CAR ;
+                    SWAP ;
+                    DUP ;
+                    DUG 2 ;
+                    CDR ;
+                    CAR ;
+                    CAR ;
+                    SWAP ;
+                    DUP ;
+                    DUG 2 ;
+                    MEM ;
+                    IF { DROP 3 ; PUSH string "FA2_INVALID_TOKEN_ID" ; FAILWITH }
+                       { PUSH nat 1 ;
+                         SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         ADD ;
+                         DUP 3 ;
+                         CDR ;
+                         DUP 4 ;
+                         CDR ;
+                         CDR ;
+                         CDR ;
+                         DUP 6 ;
+                         CAR ;
+                         DUP 5 ;
+                         SWAP ;
+                         SOME ;
+                         SWAP ;
+                         UPDATE ;
+                         SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         CDR ;
+                         CAR ;
+                         PAIR ;
+                         SWAP ;
+                         CAR ;
+                         PAIR ;
+                         DUP ;
+                         CDR ;
+                         DUG 2 ;
+                         CAR ;
+                         CAR ;
+                         PAIR ;
+                         PAIR ;
+                         DIG 2 ;
+                         CAR ;
+                         DIG 3 ;
+                         CDR ;
+                         SOME ;
+                         DIG 3 ;
+                         PUSH nat 1 ;
+                         SWAP ;
+                         PAIR ;
+                         SWAP ;
+                         PAIR ;
+                         CONS ;
+                         PAIR } } ;
+             DUP ;
+             CDR ;
+             LAMBDA
+               (pair (pair address address) (pair nat (big_map (pair address (pair address nat)) unit)))
+               unit
+               { DROP ; UNIT } ;
+             NIL (pair (option address) (list (pair (option address) (pair nat nat)))) ;
+             NONE address ;
+             DIG 4 ;
+             CAR ;
+             SWAP ;
+             PAIR ;
+             CONS ;
+             PAIR ;
+             PAIR ;
+             DIG 2 ;
+             SWAP ;
+             EXEC ;
+             UNPAIR ;
+             DUP 3 ;
+             CDR ;
+             DIG 2 ;
+             DIG 3 ;
+             CAR ;
+             CAR ;
+             PAIR ;
+             PAIR ;
+             SWAP ;
+             PAIR } } }
+

--- a/tests/unit_tests/test_contract/contracts/storage_for_data_conversion_test.tz
+++ b/tests/unit_tests/test_contract/contracts/storage_for_data_conversion_test.tz
@@ -1,0 +1,27 @@
+Pair (Pair (Pair (Pair "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" False) None)
+            (Pair { Elt 1 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" ;
+                    Elt 2 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" ;
+                    Elt 3 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" ;
+                    Elt 4 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" ;
+                    Elt 5 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb" }
+                  6)
+            { Elt (Pair "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"
+                        "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"
+                        1)
+                  Unit }
+            { Elt 1
+                  (Pair 1
+                        { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e2f31 }) ;
+              Elt 2
+                  (Pair 2
+                        { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e2f32 }) ;
+              Elt 3
+                  (Pair 3
+                        { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e2f33 }) ;
+              Elt 4
+                  (Pair 4
+                        { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e2f34 }) ;
+              Elt 5
+                  (Pair 5
+                        { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e2f35 }) })
+      { Elt "" 0x68747470733a2f2f6578616d706c652e636f6d2f7368696e79546f6b656e }

--- a/tests/unit_tests/test_contract/test_data_conversion.py
+++ b/tests/unit_tests/test_contract/test_data_conversion.py
@@ -1,0 +1,31 @@
+import io
+
+from pathlib import Path
+from unittest import TestCase
+
+from pytezos import ContractInterface
+
+
+class TestDataConversion(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        asset_directory = Path(__file__).parent.joinpath('contracts')
+        contract_path = asset_directory.joinpath('contract_for_data_conversion_test.tz')
+        with io.open(contract_path, 'r') as contract_input:
+            cls.michelson_contract = contract_input.read()
+        storage_path = asset_directory.joinpath('storage_for_data_conversion_test.tz')
+        with io.open(storage_path, 'r') as contract_data_input:
+            cls.michelson_storage = contract_data_input.read()
+
+    def test_decode_from_michelson(self):
+        """
+        Ensure that a valid Michelson contract with valid storage can be instantiated in Python
+        """
+        contract_interface = ContractInterface.from_michelson(self.michelson_contract)
+        python_storage = contract_interface.contract.storage.decode(self.michelson_storage)
+        self.assertIsNotNone(python_storage, msg="Why couldn't the valid storage be decoded from Michelson?")
+        contract_interface.contract.storage_from_michelson(self.michelson_storage)
+
+        micheline_storage = contract_interface.contract.storage.encode(python_storage)
+        self.assertIsNotNone(micheline_storage, msg="Why couldn't python_storage (the result of decoding) be submitted "
+                                                    "for encoding?")


### PR DESCRIPTION
This PR resolves an exception I was experiencing when trying to load Michelson storage into my Python contract, before publishing.

You'll see that if my changes to lazy_diff are reverted to the default `lazy_diff=False`, then there'll be an exception:

```
raise MichelsonRuntimeError(*e.args) from e
pytezos.michelson.micheline.MichelsonRuntimeError: ('pair', 'pair', 'big_map', 'Big_map id is not defined')
```
This was happening even when none of my big_maps were empty.