### PR TITLE
Fix #295: send() with min_confirmations

### DIFF
--- a/src/pytezos/rpc/shell.py
+++ b/src/pytezos/rpc/shell.py
@@ -85,7 +85,7 @@ class ShellQuery(RpcQuery, path=''):
 
         if time_between_blocks is None:
             constants = self.blocks[current_block_hash].context.constants()
-            time_between_blocks = int(constants.get('minimal_block_delay'))
+            time_between_blocks = int(constants.get('minimal_block_delay', 0))
 
         if block_timeout is None:
             block_timeout = MAX_BLOCK_TIMEOUT


### PR DESCRIPTION
Use 0 by default as we used to.

Fixes::

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/jpic/src/djwebdapp/env/lib/python3.10/site-packages/pytezos/operation/group.py", line 339, in send
        res = opg.inject(min_confirmations=min_confirmations, num_blocks_wait=ttl)
      File "/home/jpic/src/djwebdapp/env/lib/python3.10/site-packages/pytezos/operation/group.py", line 404, in inject
        operations = self.shell.wait_operations(
      File "/home/jpic/src/djwebdapp/env/lib/python3.10/site-packages/pytezos/rpc/shell.py", line 154, in wait_operations
        for block_hash in self.wait_blocks(
      File "/home/jpic/src/djwebdapp/env/lib/python3.10/site-packages/pytezos/rpc/shell.py", line 88, in wait_blocks
        time_between_blocks = int(constants.get('minimal_block_delay'))
    TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'