### PR TITLE
Wait helper: pending operation can be already included

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Fixed
 
 * Wait helper edge case: operations can be both included in chain and present in mempool
+* Batch operation build was accompanied by many useless RPC requests
 * `minimal_block_delay` constant might be absent, defaults to 0 (by @jpic)
 
 ### Changed
 
 * Minimum Python version is now 3.8, Python 3.10 support is added
+* `ReorgError` is now thrown while waiting for operation confirmation instead of `StopIteration` in case of a chain reorg.
 
 ## 3.4.2 - 2022-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 3.4.2 - 2022-03-26
+## [3.5.0](https://github.com/baking-bad/pytezos/compare/3.4.2...3.5.0) (2022-04-29)
 
 ### Fixed
+
+* Wait helper edge case: operations can be both included in chain and present in mempool
+* `minimal_block_delay` constant might be absent, defaults to 0 (by @jpic)
+
+### Changed
+
+* Minimum Python version is now 3.8, Python 3.10 support is added
+
+## 3.4.2 - 2022-03-26
+
+### Fixed`
 
 * time_between_blocks no longer exists, minimum_block_delay used instead
 * sandbox tests -> re-create node container per each case (cannot rollback in Tenderbake)

--- a/src/pytezos/context/impl.py
+++ b/src/pytezos/context/impl.py
@@ -71,13 +71,6 @@ class ExecutionContext(AbstractContext):
         raise ValueError("It's not allowed to copy context")
 
     @property
-    def constants(self):
-        if self.shell is None:
-            raise Exception('`shell` is not set')
-        # FIXME: Cached, can be an issue when switching between protocols
-        return self.shell.block.context.constants()
-
-    @property
     def script(self) -> Optional[dict]:
         if self.parameter_expr and self.storage_expr and self.code_expr:
             return dict(code=[self.parameter_expr, self.storage_expr, self.code_expr, *self.views_expr],

--- a/src/pytezos/context/impl.py
+++ b/src/pytezos/context/impl.py
@@ -326,7 +326,7 @@ class ExecutionContext(AbstractContext):
         elif self.shell:
             ts = self.shell.head.header()['timestamp']
             dt = datetime.strptime(ts, '%Y-%m-%dT%H:%M:%SZ')
-            first_delay = self.constants['minimal_block_delay']
+            first_delay = self.shell.head.context.constants().get('minimal_block_delay', 0)
             return int((dt - datetime(1970, 1, 1)).total_seconds()) + int(first_delay)
         else:
             return 0

--- a/src/pytezos/operation/group.py
+++ b/src/pytezos/operation/group.py
@@ -122,6 +122,7 @@ class OperationGroup(ContextMixin, ContentMixin):
         protocol = self.protocol or self.context.get_protocol()
         branch = self.branch or self.shell.blocks[f'head~{MAX_OPERATIONS_TTL - ttl}'].hash()
         source = self.key.public_key_hash()
+        constants = self.shell.head.context.constants()
 
         if counter is not None:
             self.context.set_counter(counter - 1)  # which is supposedly the current state (head)
@@ -134,10 +135,10 @@ class OperationGroup(ContextMixin, ContentMixin):
             'secret': lambda x: self.key.activation_code,
             'period': lambda x: str(self.shell.head.voting_period()),
             'public_key': lambda x: self.key.public_key(),
-            'gas_limit': lambda x: str(gas_limit) if gas_limit is not None else str(default_gas_limit(x, self.context.constants)),
+            'gas_limit': lambda x: str(gas_limit) if gas_limit is not None else str(default_gas_limit(x, constants)),
             'storage_limit': lambda x: str(storage_limit)
             if storage_limit is not None
-            else str(default_storage_limit(x, self.context.constants)),
+            else str(default_storage_limit(x, constants)),
             'fee': lambda x: str(default_fee(x, gas_limit, minimal_nanotez_per_gas_unit)),
         }
 
@@ -237,6 +238,7 @@ class OperationGroup(ContextMixin, ContentMixin):
             raise RpcError.from_errors(OperationResult.errors(opg_with_metadata))
 
         extra_size = (32 + 64) // len(opg.contents) + 1  # size of serialized branch and signature
+        counter_offset = self.context.get_counter_offset()
 
         def fill_content(content: Dict[str, Any]) -> Dict[str, Any]:
             if validation_passes[content['kind']] == 3:
@@ -262,7 +264,7 @@ class OperationGroup(ContextMixin, ContentMixin):
                     gas_limit=str(_gas_limit),
                     storage_limit=str(_storage_limit),
                     fee=str(_fee),
-                    counter=str(current_counter + self.context.get_counter_offset()),
+                    counter=str(current_counter + counter_offset),
                 )
 
             content.pop('metadata')

--- a/src/pytezos/operation/group.py
+++ b/src/pytezos/operation/group.py
@@ -136,9 +136,7 @@ class OperationGroup(ContextMixin, ContentMixin):
             'period': lambda x: str(self.shell.head.voting_period()),
             'public_key': lambda x: self.key.public_key(),
             'gas_limit': lambda x: str(gas_limit) if gas_limit is not None else str(default_gas_limit(x, constants)),
-            'storage_limit': lambda x: str(storage_limit)
-            if storage_limit is not None
-            else str(default_storage_limit(x, constants)),
+            'storage_limit': lambda x: str(storage_limit) if storage_limit is not None else str(default_storage_limit(x, constants)),
             'fee': lambda x: str(default_fee(x, gas_limit, minimal_nanotez_per_gas_unit)),
         }
 

--- a/src/pytezos/rpc/errors.py
+++ b/src/pytezos/rpc/errors.py
@@ -1,6 +1,18 @@
 from pytezos.rpc.node import RpcError
 
 
+class ReorgError(Exception):
+
+    def __init__(self, level, old_hash, new_hash):
+        super(ReorgError, self).__init__(level, old_hash, new_hash)
+        self.level = level
+        self.old_hash = old_hash
+        self.new_hash = new_hash
+
+    def __repr__(self):
+        return f'Reorg detected at level {self.level}: {self.old_hash} -> {self.new_hash}'
+
+
 class MichelsonBadContractParameter(RpcError, error_id='michelson_v1.bad_contract_parameter'):
     """ Either no parameter was supplied to a contract with a non-unit parameter type, a non-unit parameter was passed
     to an account, or a parameter was supplied of the wrong type

--- a/src/pytezos/rpc/shell.py
+++ b/src/pytezos/rpc/shell.py
@@ -168,14 +168,15 @@ class ShellQuery(RpcQuery, path=''):
                             logger.info('Operation %s has left mempool', opg_hash)
                             pending.remove(opg_hash)
 
-            if len(pending) < len(opg_hashes):
-                included = self.blocks[block_hash].operation_hashes()
-                for i, vp in enumerate(included):
-                    for j, opg_hash in enumerate(vp):
-                        if opg_hash in opg_hashes and opg_hash not in confirmations:
-                            logger.info('Operation %s has been included to block %s', opg_hash, block_hash)
-                            confirmations[opg_hash] = 0  # initialize
-                            operations.append(self.blocks[block_hash].operations[i][j]())
+            included = self.blocks[block_hash].operation_hashes()
+            for i, vp in enumerate(included):
+                for j, opg_hash in enumerate(vp):
+                    if opg_hash in opg_hashes and opg_hash not in confirmations:
+                        logger.info('Operation %s has been included to block %s', opg_hash, block_hash)
+                        if opg_hash in pending:  # can be still in the particular node's mempool (not yet removed)
+                            pending.remove(opg_hash)
+                        confirmations[opg_hash] = 0  # initialize
+                        operations.append(self.blocks[block_hash].operations[i][j]())
 
             for opg_hash in confirmations:
                 confirmations[opg_hash] += 1

--- a/src/pytezos/rpc/shell.py
+++ b/src/pytezos/rpc/shell.py
@@ -11,11 +11,11 @@ from deprecation import deprecated  # type: ignore
 from pytezos.crypto.encoding import base58_decode
 from pytezos.jupyter import get_attr_docstring
 from pytezos.logging import logger
+from pytezos.rpc.errors import ReorgError
 from pytezos.rpc.kind import validation_passes
 from pytezos.rpc.protocol import BlockQuery, BlocksQuery
 from pytezos.rpc.query import RpcQuery
 from pytezos.rpc.search import CyclesQuery, VotingPeriodsQuery
-from pytezos.rpc.errors import ReorgError
 
 MAX_BLOCK_TIMEOUT = 86400
 

--- a/src/pytezos/sandbox/node.py
+++ b/src/pytezos/sandbox/node.py
@@ -180,12 +180,7 @@ class SandboxedNodeAutoBakeTestCase(SandboxedNodeTestCase):
         if cls.node_container is None:
             raise RuntimeError('sandboxed node container is not created')
         cls.exit_event = Event()  # type: ignore
-        cls.baker = cls.executor.submit(
-            cls.autobake,
-            cls.TIME_BETWEEN_BLOCKS,
-            cls.node_container.url,
-            cls.exit_event,
-            cls.min_fee)
+        cls.baker = cls.executor.submit(cls.autobake, cls.TIME_BETWEEN_BLOCKS, cls.node_container.url, cls.exit_event, cls.min_fee)
         cls.baker.add_done_callback(worker_callback)
 
     @classmethod

--- a/src/pytezos/sandbox/node.py
+++ b/src/pytezos/sandbox/node.py
@@ -154,19 +154,20 @@ class SandboxedNodeTestCase(unittest.TestCase):
 class SandboxedNodeAutoBakeTestCase(SandboxedNodeTestCase):
     exit_event: Optional[Event] = None
     baker: Optional[Future] = None
+    min_fee = 0
 
     TIME_BETWEEN_BLOCKS = 3
     "Time delay between bake attempts, in seconds"
 
     @staticmethod
-    def autobake(time_between_blocks: int, node_url: str, exit_event: Event):
+    def autobake(time_between_blocks: int, node_url: str, exit_event: Event, min_fee=0):
         logging.info("Baker thread started")
         client = PyTezosClient().using(shell=node_url)
         ptr = 0
         while not exit_event.is_set():
             if ptr % time_between_blocks == 0:
                 key = get_next_baker_key(client)
-                client.using(key=key).bake_block().fill().work().sign().inject()
+                client.using(key=key).bake_block(min_fee=min_fee).fill().work().sign().inject()
             sleep(1)
             ptr += 1
         logging.info("Baker thread stopped")
@@ -179,7 +180,12 @@ class SandboxedNodeAutoBakeTestCase(SandboxedNodeTestCase):
         if cls.node_container is None:
             raise RuntimeError('sandboxed node container is not created')
         cls.exit_event = Event()  # type: ignore
-        cls.baker = cls.executor.submit(cls.autobake, cls.TIME_BETWEEN_BLOCKS, cls.node_container.url, cls.exit_event)
+        cls.baker = cls.executor.submit(
+            cls.autobake,
+            cls.TIME_BETWEEN_BLOCKS,
+            cls.node_container.url,
+            cls.exit_event,
+            cls.min_fee)
         cls.baker.add_done_callback(worker_callback)
 
     @classmethod

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-import michelson_kernel # pylint: disable=unused-import
+import michelson_kernel  # pylint: disable=unused-import

--- a/tests/integration_tests/test_injection.py
+++ b/tests/integration_tests/test_injection.py
@@ -1,6 +1,9 @@
+import logging
 from unittest import TestCase, skip
 
 from pytezos import pytezos
+
+logging.basicConfig(level=logging.INFO)
 
 
 class TestInjection(TestCase):
@@ -9,3 +12,11 @@ class TestInjection(TestCase):
     def test_one(self):
         counter = pytezos.using('florencenet').contract('KT1ECSt8FzxAtHxoxi4xN1JwkKUbBe4TS9kz')
         res = counter.increment(1).send(min_confirmations=3)
+
+    @skip
+    def test_batch(self):
+        operations = [
+            pytezos.transaction(destination=pytezos.key.public_key_hash(), amount=1)
+            for _ in range(41)
+        ]
+        res = pytezos.bulk(*operations).send(ttl=60, min_confirmations=1)


### PR DESCRIPTION
Resolves #297 

Based on
```
2022-04-26 01:58:16.147Z INFO shell Found new block BMMcivYhsijhCNq7PqqTVKyFAKWgCgow1WBF8K2NbUs8Xxv35aC (0 sec delay)
2022-04-26 01:58:17.102Z INFO shell Operation oopwxbhhcCfCm27Gg5aJ16jCG93f9BYLY71untJoEbktZQ55MpA is still in mempool
2022-04-26 01:58:17.622Z INFO shell Sleep 28 seconds until block BMMcivYhsijhCNq7PqqTVKyFAKWgCgow1WBF8K2NbUs8Xxv35aC is superseded
```

and given that operation was included in that block https://tzkt.io/oopwxbhhcCfCm27Gg5aJ16jCG93f9BYLY71untJoEbktZQ55MpA I think this is the case.

