### PR TITLE
feat(lima): add `LAMBDA_REC` instruction

### DIFF
--- a/src/pytezos/michelson/instructions/control.py
+++ b/src/pytezos/michelson/instructions/control.py
@@ -72,6 +72,14 @@ class LambdaInstruction(MichelsonInstruction, prim='LAMBDA', args_len=3):
         stdout.append(format_stdout(cls.prim, [], [res]))  # type: ignore
         return cls(stack_items_added=1)
 
+class LambdaRecInstruction(MichelsonInstruction, prim='LAMBDA_REC', args_len=3):
+    @classmethod
+    def execute(cls, stack: MichelsonStack, stdout: List[str], context: AbstractContext):
+        lambda_type = LambdaType.create_type(args=cls.args[:2])
+        res = lambda_type(cls.args[2])  # type: ignore
+        stack.push(res)
+        stdout.append(format_stdout(cls.prim, [], [res]))  # type: ignore
+        return cls(stack_items_added=1)
 
 class ExecInstruction(MichelsonInstruction, prim='EXEC'):
     def __init__(self, item: MichelsonInstruction):

--- a/src/pytezos/michelson/tags.py
+++ b/src/pytezos/michelson/tags.py
@@ -156,6 +156,9 @@ prim_tags = {
     'sapling_transaction': b'\x96',
     # KATHMANDU
     'EMIT': b'\x97',
+    # Lima
+    'Lambda_rec': b'\x98',
+    'LAMBDA_REC': b'\x99',
     # FIXME: Dummy values for TZT, refactor macros
     'Stack_elt': b'\xEE',
     'Big_map': b'\xEE',

--- a/tests/unit_tests/test_michelson/test_repl/opcodes/lambda_rec.tz
+++ b/tests/unit_tests/test_michelson/test_repl/opcodes/lambda_rec.tz
@@ -1,0 +1,9 @@
+{ parameter unit;
+  storage unit;
+  code { CAR;
+         LAMBDA_REC unit unit
+                    { EXEC };
+         SWAP;
+         EXEC;
+         NIL operation;
+         PAIR}}

--- a/tests/unit_tests/test_michelson/test_repl/test_opcodes.py
+++ b/tests/unit_tests/test_michelson/test_repl/test_opcodes.py
@@ -1090,6 +1090,8 @@ class OpcodesTestCase(TestCase):
             ),
             # Test event emitting
             ('emit.tz', 'Unit', 'Unit', 'Unit'),
+            # Test recursive lambda
+            ('lambda_rec.tz', 'Unit', 'Unit', 'Unit'),
         ]
     )
     def test_opcodes(self, filename, storage, parameter, result):


### PR DESCRIPTION
Adds support for the new instruction [LAMBDA_REC](https://tezos.gitlab.io/michelson-reference/#instr-LAMBDA_REC). The instruction was included in the Lima protocol.